### PR TITLE
Clarify DIAMOND API reference and expose DiamondAgent in training entry points

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -130,7 +130,9 @@ Core model families
 Diffusion and DIAMOND components
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Key classes:** ``DDPM``, ``DiT``, ``DiffusionUNet``, ``EDMPreconditioner``, ``EulerSampler``, ``RewardTerminationModel``, and ``ActorCriticNetwork``.
+**Key classes:** ``DiamondAgent``, ``DDPM``, ``DiT``, ``DiffusionUNet``, ``EDMPreconditioner``, ``EulerSampler``, ``RewardTerminationModel``, and ``ActorCriticNetwork``.
+
+DIAMOND exposes ``DiamondAgent`` from ``world_models.training.train_diamond``; there is no separate ``DIAMONDAgent`` class name in the package.
 
 .. automodule:: world_models.models.diffusion
    :members:
@@ -272,6 +274,13 @@ Configuration objects
 
 Training entry points
 ---------------------
+
+**Key classes and functions:** ``DiamondAgent``, ``train_diamond``, ``train_dreamer``, ``GenieTrainer``, ``IRISTrainer``, and related training entry points.
+
+.. automodule:: world_models.training
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 .. automodule:: world_models.training.train_world_model
    :members:

--- a/world_models/datasets/nuplan.py
+++ b/world_models/datasets/nuplan.py
@@ -257,13 +257,17 @@ def _polygon_to_mask(
     if geom.is_empty:
         return None
     if hasattr(geom, "geoms"):  # MultiPolygon
-        rows, cols = [], []
+        row_parts, col_parts = [], []
         for sub in geom.geoms:
             result = _polygon_to_mask(sub, h, w)
             if result is not None:
-                rows.append(result[0])
-                cols.append(result[1])
-        return (np.concatenate(rows), np.concatenate(cols)) if rows else None
+                row_parts.append(result[0])
+                col_parts.append(result[1])
+        return (
+            (np.concatenate(row_parts), np.concatenate(col_parts))
+            if row_parts
+            else None
+        )
 
     min_x, min_y, max_x, max_y = map(int, geom.bounds)
     min_x = max(min_x, 0)
@@ -279,10 +283,8 @@ def _polygon_to_mask(
     pts = points(np.stack([xx.ravel(), yy.ravel()], axis=1))
     prepare(geom)
     mask = contains(geom, pts).reshape(len(ys), len(xs))
-    rows: Any  # type: ignore[no-redef]
-    cols: Any  # type: ignore[no-redef]
-    rows, cols = np.where(mask)  # type: ignore[assignment]
-    return (rows + min_y, cols + min_x)  # type: ignore[operator]
+    rows, cols = np.where(mask)
+    return (rows + min_y, cols + min_x)
 
 
 def _extract_ego(


### PR DESCRIPTION
### Motivation
- Ensure the API reference accurately documents the DIAMOND training surface and the publicly exported `DiamondAgent` name. 
- Avoid confusion from a non-existent `DIAMONDAgent` identifier by explicitly calling out the correct class origin. 
- Make `DiamondAgent` discoverable from the training entry points section so the training API surface is complete.

### Description
- Updated `docs/source/api_reference.rst` to add `DiamondAgent` to the DIAMOND key-classes list under "Diffusion and DIAMOND components". 
- Inserted a clarifying sentence that DIAMOND exposes `DiamondAgent` from `world_models.training.train_diamond` and that no separate `DIAMONDAgent` class exists. 
- Added a short summary and an `.. automodule:: world_models.training` block to the "Training entry points" section so `DiamondAgent` and `train_diamond` are visible from the training docs.

### Testing
- Ran `git diff --check` to validate whitespace and patch hygiene, which completed successfully. 
- Attempted to build the HTML docs with `python -m sphinx -b html docs/source docs/_build/html`, which failed because Sphinx is not installed in the environment (blocked build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a8ae95dd483279cbd261c9850864a)