### PR TITLE
Add DreamerV3 implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **DreamerV3** (`create_model("dreamer-v3")`), replacing the placeholder that
+  previously aliased `dreamer-v3` to the DreamerV1 agent. Implements the paper's
+  robustness techniques: categorical latents with 1% unimix and straight-through
+  gradients, separate dynamics/representation KL terms with free bits, symexp
+  two-hot reward and critic heads, percentile return normalization with a
+  denominator limit, a critic EMA regularizer and replay loss, zero-initialized
+  head outputs, and LaProp with adaptive gradient clipping
+- `DreamerV3Config` with the paper's Table 4 defaults and the 12M-400M model-size
+  presets from Table 3; widths resolve from `model_size` and `update_steps`
+  derives from `replay_ratio`
+- `CategoricalRSSM`, `DreamerV3Encoder`/`Decoder`/`Head`/`Actor`,
+  `DreamerV3ReplayBuffer`, `BlockGRUCell`/`BlockLinear`, and a new
+  `world_models.optim` package exporting `LaProp` and `adaptive_grad_clip_` --
+  all usable independently of the agent
+- Discrete action support in the shared Dreamer `make_env`: environments with a
+  discrete action space are now wrapped with `OneHotAction` instead of failing in
+  `NormalizeActions`
+- `examples/dreamer_v3_example.py` and the {doc}`dreamer_v3` documentation page
 - `dmc` optional-dependency extra (`pip install torchwm[dmc]`) that installs
   `dm-control` for the default DeepMind Control backend
 - Actionable error from the DMC backend that names the missing `dm_control`
   dependency and points to `torchwm[dmc]` or the gym backend
 
 ### Changed
+- `DreamerAgent` is now subclassable: `_config_cls` selects the configuration
+  class and `_build_core` selects the algorithm core, so the shared environment,
+  seeding, logging, and checkpoint loop is reused rather than duplicated
+- Passing a base `DreamerConfig` to a subclass agent carries over only the fields
+  that were actually changed, so the subclass's tuned defaults are not silently
+  overwritten by base-class defaults
+- The Dreamer training loop logs any extra metrics an algorithm core publishes via
+  `last_metrics` (DreamerV3 reports its individual loss terms, gradient norms, and
+  return scale)
 - Quick-start examples (README, docs landing page, getting-started guide) now use
   the base-installable `Pendulum-v1` gym backend so they run on
   `pip install torchwm[gym]` out of the box; DMC usage is documented separately

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ agent.train()
 ## Features
 
 - Unified interfaces across world-model algorithms
+- DreamerV3 with fixed hyperparameters across domains, and 12M-400M model-size presets
 - Modular encoders, decoders, dynamics models, and backbones
 - Training and inference utilities for model-based reinforcement learning
 - Environment integrations for Gym/Gymnasium, Unity ML-Agents, MuJoCo, Brax, and robotics extras
@@ -83,7 +84,7 @@ flowchart LR
     end
 
     subgraph CONFIGS["Configs"]
-        DC["DreamerConfig"]
+        DC["DreamerConfig / DreamerV3Config"]
         JC["JEPAConfig"]
         IC["IRISConfig"]
         GC["GenieConfig"]
@@ -91,7 +92,7 @@ flowchart LR
     end
 
     subgraph AGENTS["Agents / Models"]
-        DR["Dreamer / DreamerV1 / DreamerV2"]
+        DR["Dreamer / DreamerV1 / DreamerV2 / DreamerV3"]
         JP["JEPAAgent"]
         IR["IRISAgent"]
         GN["Genie"]
@@ -99,7 +100,7 @@ flowchart LR
     end
 
     subgraph BACKBONES["Backbones"]
-        RSSM["RSSM / ModularRSSM"]
+        RSSM["RSSM / CategoricalRSSM / ModularRSSM"]
         VIT["VisionTransformer"]
         VQ["VQ-VAE / VideoTokenizer"]
         ST["STTransformer"]

--- a/docs/source/api_reference.md
+++ b/docs/source/api_reference.md
@@ -37,7 +37,9 @@ This page lists every public class, function, and constant exported from the
 | `Dreamer` | `world_models.models.dreamer` | Base Dreamer world model (RSSM-based, V1-style). |
 | `DreamerV1` | `world_models.models.dreamer_v1` | DreamerV1 (alias for base Dreamer). |
 | `DreamerV2` | `world_models.models.dreamer_v2` | DreamerV2 (symlog two-hot heads, balanced KL). |
-| `DreamerV3` | `world_models.models.dreamer` | DreamerV3-style agent (currently mapped to DreamerAgent). |
+| `DreamerV3` | `world_models.models.dreamer_v3` | DreamerV3 core model (categorical latents, free bits, return normalization). |
+| `DreamerV3Agent` | `world_models.models.dreamer_v3` | High-level DreamerV3 agent with train/evaluate helpers. |
+| `CategoricalRSSM` | `world_models.models.categorical_rssm` | DreamerV3 RSSM with straight-through categorical latents. |
 | `DreamerAgent` | `world_models.models.dreamer` | High-level Dreamer agent with train/evaluate helpers. |
 | `Planet` | `world_models.models.planet` | PlaNet: Deep Planning Network. |
 | `JEPAAgent` | `world_models.models.jepa_agent` | I-JEPA agent for self-supervised visual representation learning. |

--- a/docs/source/configs_reference.md
+++ b/docs/source/configs_reference.md
@@ -157,6 +157,86 @@ class DreamerConfig:
     detect_anomaly: bool = False
 ```
 
+## DreamerV3Config
+
+Configuration for DreamerV3. It subclasses `DreamerConfig`, so every environment
+backend option above carries over unchanged; the fields below are either new or
+override a base default.
+
+```python
+@dataclass
+class DreamerV3Config(DreamerConfig):
+    algo: str = "DreamerV3"
+
+    # Architecture. Width fields left as None are filled in from model_size.
+    model_size: str = "12m"          # 12m | 25m | 50m | 100m | 200m | 400m
+    hidden_size: Optional[int] = None
+    recurrent_units: Optional[int] = None
+    cnn_depth: Optional[int] = None
+    latent_classes: Optional[int] = None
+    latent_dim: int = 32
+    gru_blocks: int = 8
+    mlp_layers: int = 3
+    activation: str = "silu"
+    unimix: float = 0.01
+    actor_dist: str = "auto"         # auto | normal | onehot
+    actor_min_std: float = 0.1
+    actor_max_std: float = 1.0
+
+    # World model losses
+    beta_pred: float = 1.0
+    beta_dyn: float = 1.0
+    beta_rep: float = 0.1
+    free_nats: float = 1.0
+
+    # Actor critic
+    discount: float = 0.997
+    td_lambda: float = 0.95
+    imagine_horizon: int = 15
+    actor_entropy: float = 3e-4
+    critic_loss_scale: float = 1.0
+    critic_replay_loss_scale: float = 0.3
+    critic_ema_decay: float = 0.98
+    critic_ema_regularizer: float = 1.0
+    return_norm_decay: float = 0.99
+    return_norm_limit: float = 1.0
+    return_norm_low: float = 5.0
+    return_norm_high: float = 95.0
+
+    # Prediction heads
+    num_buckets: int = 255
+    symlog_range: float = 20.0
+
+    # Optimization
+    learning_rate: float = 4e-5      # shared by all three optimizers
+    agc_clip: float = 0.3
+    agc_eps: float = 1e-3
+    opt_eps: float = 1e-20
+    opt_beta1: float = 0.9
+    opt_beta2: float = 0.99
+    weight_decay: float = 0.0
+    batch_size: int = 16
+    train_seq_len: int = 64
+    replay_ratio: int = 32
+    auto_update_steps: bool = True
+    online_fraction: float = 0.5
+    buffer_size: int = 1_000_000
+    use_amp: bool = False
+```
+
+Two fields behave differently from the rest:
+
+- Width fields (`hidden_size`, `recurrent_units`, `cnn_depth`, `latent_classes`)
+  resolve from `model_size` at construction time when left as `None`. Setting one
+  explicitly overrides the preset for that field only.
+- `update_steps` is derived from `replay_ratio` unless `auto_update_steps=False`.
+
+Passing a plain `DreamerConfig` to `DreamerV3Agent` upgrades it, carrying over only
+the fields you actually changed. Fields left at their base defaults keep DreamerV3's
+own tuned values, so the agent never silently trains with V1 hyperparameters.
+
+See {doc}`dreamer_v3` for what each field does.
+
 ## JEPAConfig
 
 Configuration for JEPA training.

--- a/docs/source/dreamer.md
+++ b/docs/source/dreamer.md
@@ -18,7 +18,9 @@ policy entirely in the imagination of that world model. No gradients flow from t
 environment to the policy — the world model is the only bridge between real
 experience and learned behavior.
 
-The family has two major versions, documented individually below.
+The family has two major versions documented on this page. DreamerV3 has its own
+page, {doc}`dreamer_v3`, because it changes the latent representation, the actor
+objective, and the optimizer rather than just the loss terms.
 
 ---
 
@@ -690,6 +692,7 @@ The prior predicts states that drift from realistic latents over long horizons.
 
 ## See Also
 
+- {doc}`dreamer_v3` — DreamerV3, which trains across domains without retuning
 - {doc}`modular_rssm_guide` — swap Dreamer's encoder, backbone, or decoder for research
 - {doc}`iris` — discrete world model alternative to Dreamer
 - {doc}`diamond` — diffusion-based world model alternative

--- a/docs/source/dreamer_v3.md
+++ b/docs/source/dreamer_v3.md
@@ -1,0 +1,382 @@
+# DreamerV3: Mastering Diverse Domains with Fixed Hyperparameters
+
+DreamerV3 is the third generation of the Dreamer family. Its distinguishing claim is
+not a new architecture but *robustness*: a single set of hyperparameters trains
+successfully across more than 150 tasks spanning continuous and discrete actions,
+image and vector observations, dense and sparse rewards, and reward scales differing
+by orders of magnitude.
+
+Based on: [Mastering Diverse Domains through World Models](https://arxiv.org/abs/2301.04104)
+(Hafner, Pasukonis, Ba & Lillicrap, 2023)
+
+```{contents} Contents
+:depth: 3
+```
+
+## Quick start
+
+```python
+import torchwm
+
+agent = torchwm.create_model(
+    "dreamer-v3",
+    env="Pendulum-v1",
+    env_backend="gym",
+    total_steps=100_000,
+)
+agent.train()
+```
+
+Scaling up is a single argument — every other hyperparameter stays fixed:
+
+```python
+agent = torchwm.create_model("dreamer-v3", env="walker-walk", model_size="200m")
+```
+
+## What changed from DreamerV2
+
+DreamerV2 already used discrete latents and two-hot heads. DreamerV3 adds the
+robustness machinery that removes the need for per-domain tuning.
+
+| Area | DreamerV2 (this repo) | DreamerV3 |
+| --- | --- | --- |
+| Latents | Gaussian (`mean`, `std`) | Categorical, 1% unimix, straight-through |
+| KL terms | Single balanced KL | Separate `L_dyn` / `L_rep` with free bits |
+| Actor objective | Backprop through dynamics | Reinforce + entropy bonus |
+| Return scaling | None | Percentile range with a denominator limit |
+| Critic | Two-hot on imagined returns | Adds EMA regularizer and a replay loss |
+| Head init | Default | Zero-initialized output weights |
+| Optimizer | Adam + norm clipping | LaProp + adaptive gradient clipping |
+| Normalization | None | RMSNorm + SiLU throughout |
+| Sequence model | Dense GRU | Block-diagonal GRU (8 blocks) |
+| Replay | Rejects episode-spanning windows | `is_first` flags plus an online queue |
+
+## Theory
+
+### World model
+
+The world model is a Recurrent State-Space Model whose stochastic state is a vector
+of categorical variables rather than a Gaussian:
+
+```{math}
+\begin{aligned}
+\text{Sequence model:} &\quad h_t = f_\phi(h_{t-1}, z_{t-1}, a_{t-1}) \\
+\text{Encoder:} &\quad z_t \sim q_\phi(z_t \mid h_t, x_t) \\
+\text{Dynamics predictor:} &\quad \hat{z}_t \sim p_\phi(\hat{z}_t \mid h_t) \\
+\text{Reward predictor:} &\quad \hat{r}_t \sim p_\phi(\hat{r}_t \mid h_t, z_t) \\
+\text{Continue predictor:} &\quad \hat{c}_t \sim p_\phi(\hat{c}_t \mid h_t, z_t) \\
+\text{Decoder:} &\quad \hat{x}_t \sim p_\phi(\hat{x}_t \mid h_t, z_t)
+\end{aligned}
+```
+
+The model state is `s_t = {h_t, z_t}`. Samples of `z_t` use straight-through
+gradients: the forward pass is a hard one-hot vector, the backward pass sees the
+softmax probabilities.
+
+### Free bits and the two KL terms
+
+The world model loss splits the KL into a **dynamics** term (train the prior towards
+the posterior) and a **representation** term (train the posterior towards the prior),
+weighted differently and each clipped below one nat:
+
+```{math}
+\begin{aligned}
+\mathcal{L}_{\text{dyn}} &= \max\big(1, \operatorname{KL}[\operatorname{sg}(q_\phi) \,\|\, p_\phi]\big) \\
+\mathcal{L}_{\text{rep}} &= \max\big(1, \operatorname{KL}[q_\phi \,\|\, \operatorname{sg}(p_\phi)]\big) \\
+\mathcal{L}(\phi) &= \beta_{\text{pred}} \mathcal{L}_{\text{pred}}
+                   + \beta_{\text{dyn}} \mathcal{L}_{\text{dyn}}
+                   + \beta_{\text{rep}} \mathcal{L}_{\text{rep}}
+\end{aligned}
+```
+
+with `β_pred = 1`, `β_dyn = 1`, `β_rep = 0.1`.
+
+This resolves a tension that previously forced per-domain tuning. Visually complex 3D
+environments need a strong regularizer to keep representations predictable; games
+where individual pixels matter need a weak one to preserve detail. Free bits switch
+each KL term off once it is already minimized, so a single small `β_rep` works for
+both.
+
+Note that `L_dyn` and `L_rep` are numerically identical — `sg` changes gradients, not
+values — so seeing them log the same number is expected, not a bug.
+
+### Unimix
+
+Every categorical (the encoder, the dynamics predictor, and a discrete policy) is a
+mixture of 99% network output and 1% uniform. A distribution can therefore never
+become deterministic, which bounds log-probabilities and keeps the KL terms finite.
+This eliminates the KL spikes observed in earlier experiments.
+
+### Two-hot reward and critic heads
+
+Rewards and values vary by orders of magnitude across domains. A squared loss on
+large targets can diverge; absolute and Huber losses stagnate; normalizing by running
+statistics makes the optimization non-stationary.
+
+Instead, the heads output logits over 255 bins placed at
+`symexp(linspace(-20, +20, 255))` and are trained with cross entropy against the
+two-hot encoding of the target. Predictions are read out as the probability-weighted
+average of the bin locations, so any continuous value in the interval is
+representable. Crucially, the loss depends only on the predicted probabilities, so
+**gradient magnitudes are decoupled from target magnitudes**.
+
+The `symlog` transform used for vector observations follows the same motivation:
+
+```{math}
+\operatorname{symlog}(x) = \operatorname{sign}(x)\ln(|x| + 1), \qquad
+\operatorname{symexp}(x) = \operatorname{sign}(x)\big(\exp(|x|) - 1\big)
+```
+
+It compresses large magnitudes of either sign while approximating the identity near
+the origin, so small targets are unaffected.
+
+### Percentile return normalization
+
+The actor uses a fixed entropy scale `η = 3e-4` across all domains. For that to work,
+returns must be brought onto a common scale without destroying the information about
+reward frequency that tells the agent whether to explore or exploit:
+
+```{math}
+S = \operatorname{EMA}\big(\operatorname{Per}(R^\lambda, 95) - \operatorname{Per}(R^\lambda, 5),\ 0.99\big)
+```
+
+Returns are divided by `max(1, S)`. Two details carry the robustness:
+
+- **Percentiles, not min/max**, so a single outlier episode does not shrink every
+  other return.
+- **The denominator limit**, so returns that are already small pass through
+  unchanged. Normalizing by standard deviation fails exactly here: under sparse
+  rewards the deviation approaches zero and amplifies noise without bound.
+
+### Actor and critic
+
+The actor maximizes the Reinforce objective with an entropy bonus, for both discrete
+and continuous actions:
+
+```{math}
+\mathcal{L}(\theta) = -\sum_{t=1}^{T}
+  \operatorname{sg}\!\left(\frac{R^\lambda_t - v_\psi(s_t)}{\max(1, S)}\right)
+  \log \pi_\theta(a_t \mid s_t)
+  + \eta\, \mathcal{H}\!\left[\pi_\theta(a_t \mid s_t)\right]
+```
+
+The critic regresses `λ`-returns with the two-hot loss and adds two extras:
+
+- an **EMA regularizer** pulling it towards an exponential moving average of its own
+  weights (decay `0.98`), which stabilizes bootstrapping without a stale target
+  network; and
+- a **replay loss** (scale `0.3`) applying the critic loss to replayed trajectories,
+  using the imagination returns at the rollout start states as on-policy value
+  annotations. This helps where rewards are hard to predict from imagination alone.
+
+Reward and critic output weights are zero-initialized so that both predict exactly
+zero at step 0, which avoids a burst of hallucinated value early in training.
+
+### Optimizer
+
+LaProp normalizes gradients by an RMSProp second-moment estimate *before* applying
+momentum, whereas Adam computes both from the raw gradient. That ordering tolerates
+`ε = 1e-20` and avoids instabilities seen with Adam.
+
+Adaptive gradient clipping scales each tensor's gradient so its norm stays under 30%
+of the norm of the weights it belongs to. Because the threshold is relative to the
+weights, it does not need retuning when loss functions or loss scales change.
+
+## Model sizes
+
+Widths derive from a single model dimension `d` (Table 3 of the paper). Larger models
+score higher **and** need less environment interaction.
+
+| Parameters | Hidden size `d` | Recurrent units | CNN channels | Codes per latent |
+| --- | --- | --- | --- | --- |
+| 12M | 256 | 1024 | 16 | 16 |
+| 25M | 384 | 3072 | 24 | 24 |
+| 50M | 512 | 4096 | 32 | 32 |
+| 100M | 768 | 6144 | 48 | 48 |
+| 200M | 1024 | 8192 | 64 | 64 |
+| 400M | 1536 | 12288 | 96 | 96 |
+
+```python
+from world_models.configs import DreamerV3Config
+
+config = DreamerV3Config(model_size="200m")   # widths filled in automatically
+config = DreamerV3Config(model_size="200m", hidden_size=896)  # override one field
+```
+
+The number of layers and the number of latents (32) are constant across sizes.
+
+```{note}
+The paper labels the recurrent column "8d", which holds for every row except 12M,
+listed as 1024 rather than 2048. `MODEL_SIZES` reproduces the table verbatim.
+```
+
+## Configuration
+
+`DreamerV3Config` extends `DreamerConfig`, so every environment backend option
+carries over. The defaults below reproduce Table 4 and are meant to be used
+unchanged.
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `model_size` | `"12m"` | Preset controlling every width |
+| `latent_dim` | 32 | Number of categorical variables |
+| `unimix` | 0.01 | Uniform mixture fraction |
+| `free_nats` | 1.0 | Free bits threshold for both KL terms |
+| `beta_pred` / `beta_dyn` / `beta_rep` | 1.0 / 1.0 / 0.1 | World model loss weights |
+| `discount` | 0.997 | Discount factor (horizon 333) |
+| `td_lambda` | 0.95 | `λ`-return trace decay |
+| `imagine_horizon` | 15 | Imagination rollout length |
+| `actor_entropy` | 3e-4 | Entropy regularizer scale |
+| `critic_ema_decay` | 0.98 | Slow critic decay |
+| `critic_replay_loss_scale` | 0.3 | Weight of the replay critic loss |
+| `return_norm_limit` | 1.0 | Denominator floor |
+| `num_buckets` | 255 | Two-hot bin count |
+| `symlog_range` | 20.0 | Half-width of the bin grid in symlog space |
+| `learning_rate` | 4e-5 | Shared across all three optimizers |
+| `agc_clip` | 0.3 | Adaptive gradient clipping fraction |
+| `batch_size` / `train_seq_len` | 16 / 64 | Minibatch shape |
+| `replay_ratio` | 32 | Time steps trained per env step collected |
+
+### Replay ratio
+
+`update_steps` is derived from `replay_ratio` rather than set directly:
+
+```
+update_steps = round(collect_steps * replay_ratio / (batch_size * train_seq_len))
+```
+
+Higher replay ratios trade compute for data efficiency, predictably. Set
+`auto_update_steps=False` to control `update_steps` yourself.
+
+## Observations and actions
+
+Both observation kinds and both action kinds are handled automatically:
+
+- **Image observations** (`(C, H, W)`) use a stride-2 convolution stack down to 4x4,
+  a sigmoid decoder output, and targets in `[0, 1]`.
+- **Vector observations** (`(D,)`) are symlog transformed and passed through an MLP,
+  which prevents large inputs from producing reconstruction gradients that swamp the
+  representation loss.
+- **Continuous actions** use a Normal with a `tanh`-squashed mean and a standard
+  deviation bounded to `[0.1, 1.0]`.
+- **Discrete actions** are wrapped as one-hot vectors by `make_env` and modeled with a
+  one-hot categorical carrying the same 1% unimix.
+
+`actor_dist` defaults to `"auto"`, which resolves from the environment's action space.
+
+## Usage
+
+### From the top-level API
+
+```python
+import torchwm
+
+config = torchwm.create_config("dreamer-v3", env="walker-walk", seed=0)
+agent = torchwm.create_model("dreamer-v3", config)
+agent.train()
+rewards, videos, latents = agent.evaluate()
+```
+
+### Direct construction
+
+```python
+from world_models.models.dreamer_v3 import DreamerV3
+from world_models.configs import DreamerV3Config
+
+model = DreamerV3(
+    DreamerV3Config(actor_dist="normal"),
+    obs_shape=(3, 64, 64),
+    action_size=6,
+    device="cuda",
+)
+model_loss, actor_loss, value_loss = model.train_one_batch()
+```
+
+### Checkpoints
+
+```python
+model.save("checkpoints/dreamer_v3.pt")           # writes config.yaml alongside
+restored = DreamerV3.from_pretrained("checkpoints")
+```
+
+Checkpoints include the slow critic and the return normalizer state, so training
+resumes exactly rather than restarting the normalization statistics.
+
+### Components in isolation
+
+Every piece is usable on its own:
+
+```python
+from world_models.models import CategoricalRSSM
+from world_models.optim import LaProp, adaptive_grad_clip_
+from world_models.layers import BlockGRUCell
+from world_models.utils.dreamer_v3_utils import ReturnNormalizer, SymexpTwoHotDist
+```
+
+## Diagnostics
+
+`train_one_batch` publishes a metrics dictionary that the training loop logs
+automatically:
+
+| Metric | What it tells you |
+| --- | --- |
+| `wm/recon_loss` | Whether the decoder is fitting observations |
+| `wm/dyn_loss`, `wm/rep_loss` | KL magnitude; both pinned at 1.0 means free bits are saturated |
+| `wm/reward_loss`, `wm/continue_loss` | Reward and termination prediction quality |
+| `actor/entropy` | Exploration level; collapsing to 0 means premature exploitation |
+| `actor/return_scale` | Current percentile range `S` |
+| `actor/advantage` | Normalized advantage; should stay near unit scale |
+| `critic/value`, `critic/target` | A persistent gap suggests the critic is lagging |
+| `grad_norm/*` | Pre-clipping gradient norms per component |
+
+## Common pitfalls
+
+### Both KL terms sit exactly at 1.0
+
+Free bits are fully saturated, so the representation is not being shaped by the
+dynamics at all. This is normal early on. If it persists, the world model may be
+underfitting — check `wm/recon_loss` is still decreasing.
+
+### Entropy collapses to zero
+
+The actor has stopped exploring. Check `actor/return_scale`: if it is very large, the
+advantages have been scaled down until the entropy term dominates nothing. Confirm
+that reward magnitudes are what you expect.
+
+### Rewards are learned but the policy does not improve
+
+Check `critic/value` against `critic/target`. A persistent gap points at the critic;
+try raising `critic_replay_loss_scale` for environments where rewards are hard to
+predict from imagination alone.
+
+### Out-of-memory with large model sizes
+
+The replay buffer sizes itself from available RAM and logs a warning when it shrinks.
+The dominant GPU cost is `batch_size * train_seq_len`; lower `train_seq_len` before
+lowering `model_size`, since sequence length costs less in final performance.
+
+## Deviations from the paper
+
+Documented here so results can be compared fairly:
+
+- `buffer_size` defaults to 1M transitions rather than 5M, and shrinks further based
+  on available RAM. Set it explicitly for long runs.
+- The critic replay loss uses the imagination return at each replay start state as
+  the value annotation, then accumulates `λ`-returns over the replayed rewards. The
+  paper describes this mechanism without fixing an implementation.
+- Prioritized replay is not implemented; the paper also opts for uniform replay.
+- Image reconstruction uses a sigmoid output against `[0, 1]` targets with a squared
+  error, matching the Methods section's description of the decoder.
+
+## See also
+
+- {doc}`dreamer` — DreamerV1 and DreamerV2
+- {doc}`modular_rssm_guide` — swapping encoders, backbones, and decoders
+- {doc}`iris` — a discrete transformer-based world model alternative
+
+## References
+
+- Hafner, D., Pasukonis, J., Ba, J., & Lillicrap, T. (2023). Mastering Diverse Domains through World Models.
+- Ziyin, L., Wang, Z. T., & Ueda, M. (2020). LaProp: Separating Momentum and Adaptivity in Adam.
+- Brock, A., De, S., Smith, S. L., & Simonyan, K. (2021). High-Performance Large-Scale Image Recognition Without Normalization.
+- Webber, J. B. W. (2012). A bi-symmetric log transformation for wide-range data.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -52,6 +52,7 @@ agents with a unified API.
    :caption: Algorithms
 
    dreamer
+   dreamer_v3
    planet
    jepa
    iris

--- a/docs/source/package_overview.md
+++ b/docs/source/package_overview.md
@@ -32,11 +32,13 @@ agent = DreamerAgent(cfg)
 | Category | Exports |
 |----------|--------|
 | **Friendly factories** | `create_config`, `create_model`, `make_env`, `list_models`, `list_env_backends`, `list_envs` |
-| **Models / Agents** | `Dreamer`, `DreamerV1`, `DreamerV2`, `DreamerV3`, `DreamerAgent`, `Planet`, `JEPAAgent`, `IRISAgent`, `Genie`, `create_genie`, `DiT`, `create_dit` |
-| **State-space models** | `RSSM`, `RecurrentStateSpaceModel`, `DreamerRSSM`, `ModularRSSM`, `create_modular_rssm` |
-| **Vision** | `ConvEncoder`, `CNNEncoder`, `IRISEncoder`, `ConvDecoder`, `CNNDecoder`, `DenseDecoder`, `ActionDecoder`, `IRISDecoder`, `VideoTokenizer`, `create_video_tokenizer` |
+| **Models / Agents** | `Dreamer`, `DreamerV1`, `DreamerV2`, `DreamerV3`, `DreamerV3Agent`, `DreamerAgent`, `Planet`, `JEPAAgent`, `IRISAgent`, `Genie`, `create_genie`, `DiT`, `create_dit` |
+| **State-space models** | `RSSM`, `RecurrentStateSpaceModel`, `DreamerRSSM`, `CategoricalRSSM`, `ModularRSSM`, `create_modular_rssm` |
+| **Vision** | `ConvEncoder`, `CNNEncoder`, `IRISEncoder`, `ConvDecoder`, `CNNDecoder`, `DenseDecoder`, `ActionDecoder`, `IRISDecoder`, `DreamerV3Encoder`, `DreamerV3Decoder`, `DreamerV3Head`, `DreamerV3Actor`, `VideoTokenizer`, `create_video_tokenizer` |
 | **Quantization** | `VectorQuantizer`, `VectorQuantizerEMA` |
-| **Configs** | `DreamerConfig`, `JEPAConfig`, `DiTConfig`, `DiamondConfig`, `IRISConfig`, `GenieConfig`, `GenieSmallConfig`, `STTransformerConfig`, `VideoTokenizerConfig`, `LatentActionModelConfig`, `DynamicsModelConfig` |
+| **Memory** | `ReplayBuffer`, `DreamerV3ReplayBuffer`, `Episode`, `IRISReplayBuffer`, `IRISOnPolicyBuffer` |
+| **Optimizers** | `LaProp`, `adaptive_grad_clip_` (from `world_models.optim`) |
+| **Configs** | `DreamerConfig`, `DreamerV3Config`, `JEPAConfig`, `DiTConfig`, `DiamondConfig`, `IRISConfig`, `GenieConfig`, `GenieSmallConfig`, `STTransformerConfig`, `VideoTokenizerConfig`, `LatentActionModelConfig`, `DynamicsModelConfig` |
 | **Environments** | `make_atari_env`, `make_gym_env`, `make_mujoco_env`, `make_robotics_env`, `make_brax_env`, `make_procgen_env`, `GymImageEnv`, `ProcgenImageEnv`, `DeepMindControlEnv`, `DMLabEnv`, `make_dmlab_env`, `UnityMLAgentsEnv`, `TimeLimit`, `ActionRepeat`, wrappers, etc. |
 | **Memory** | `ReplayBuffer`, `Memory`, `Episode`, `IRISReplayBuffer`, `IRISOnPolicyBuffer` |
 | **Operators** | `get_operator`, `DreamerOperator`, `JEPAOperator`, `IrisOperator`, `PlaNetOperator` |

--- a/examples/dreamer_v3_example.py
+++ b/examples/dreamer_v3_example.py
@@ -1,0 +1,82 @@
+"""
+Example script for training a DreamerV3 agent.
+
+DreamerV3 is designed to run with fixed hyperparameters across domains, so this
+script deliberately exposes very few knobs: the environment, the budget, and the
+model size. Everything else is left at the paper defaults.
+
+Usage::
+
+    # Runs on a base `pip install torchwm[gym]`.
+    python examples/dreamer_v3_example.py env=Pendulum-v1 env_backend=gym
+
+    # DeepMind Control, larger model (requires `pip install torchwm[dmc]`).
+    python examples/dreamer_v3_example.py env=walker-walk model_size=200m
+
+    # Atari, discrete actions handled automatically.
+    python examples/dreamer_v3_example.py env=ALE/Pong-v5 env_backend=gym
+"""
+
+import logging
+
+from omegaconf import OmegaConf
+
+from world_models.configs.dreamer_v3_config import MODEL_SIZES, DreamerV3Config
+from world_models.models.dreamer_v3 import DreamerV3Agent
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    cli_cfg = OmegaConf.from_cli()
+
+    env = cli_cfg.get("env", "Pendulum-v1")
+    env_backend = cli_cfg.get("env_backend", "gym")
+    total_steps = int(cli_cfg.get("total_steps", 100_000))
+    model_size = str(cli_cfg.get("model_size", "12m"))
+    seed = int(cli_cfg.get("seed", 0))
+    logdir = cli_cfg.get("logdir", None)
+    device = cli_cfg.get("device", "auto")
+
+    if model_size not in MODEL_SIZES:
+        raise SystemExit(
+            f"Unknown model_size={model_size!r}. "
+            f"Choose one of: {', '.join(MODEL_SIZES)}"
+        )
+
+    config = DreamerV3Config(
+        env=env,
+        env_backend=env_backend,
+        total_steps=total_steps,
+        model_size=model_size,
+        seed=seed,
+    )
+    if device != "auto":
+        config.no_gpu = device == "cpu"
+
+    logger.info("Training DreamerV3 on %s (%s backend)", env, env_backend)
+    logger.info(
+        "Model size %s: hidden=%s recurrent=%s latent=%sx%s",
+        model_size,
+        config.resolved_hidden_size,
+        config.resolved_recurrent_units,
+        config.latent_dim,
+        config.resolved_latent_classes,
+    )
+    logger.info(
+        "Replay ratio %s -> %s gradient steps per %s collected steps",
+        config.replay_ratio,
+        config.update_steps,
+        config.collect_steps,
+    )
+
+    agent = DreamerV3Agent(config, logdir=logdir)
+    logger.info("Parameters: %s", f"{agent.parameter_count():,}")
+
+    agent.train(total_steps=total_steps)
+    logger.info("Training completed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/memory/test_dreamer_v3_memory.py
+++ b/tests/memory/test_dreamer_v3_memory.py
@@ -1,0 +1,199 @@
+"""Tests for the DreamerV3 replay buffer."""
+
+import numpy as np
+import pytest
+
+from world_models.memory.dreamer_v3_memory import DreamerV3ReplayBuffer
+
+
+def make_buffer(size=64, seq_len=4, batch_size=3, online_fraction=0.0):
+    return DreamerV3ReplayBuffer(
+        size=size,
+        obs_shape=(3, 8, 8),
+        action_size=2,
+        seq_len=seq_len,
+        batch_size=batch_size,
+        online_fraction=online_fraction,
+    )
+
+
+def fill(buffer, steps, episode_length=None):
+    for step in range(steps):
+        done = episode_length is not None and (step + 1) % episode_length == 0
+        buffer.add(
+            {"image": np.full((3, 8, 8), step % 256, dtype=np.uint8)},
+            np.array([step, -step], dtype=np.float32),
+            float(step),
+            done,
+        )
+
+
+class TestConstruction:
+    def test_rejects_short_sequences(self):
+        with pytest.raises(ValueError, match="seq_len"):
+            make_buffer(seq_len=1)
+
+    def test_rejects_invalid_online_fraction(self):
+        with pytest.raises(ValueError, match="online_fraction"):
+            DreamerV3ReplayBuffer(
+                8, (3,), 1, seq_len=2, batch_size=1, online_fraction=1.5
+            )
+
+    def test_starts_empty(self):
+        buffer = make_buffer()
+        assert len(buffer) == 0
+        assert not buffer.can_sample
+
+
+class TestWriting:
+    def test_tracks_steps_and_episodes(self):
+        buffer = make_buffer()
+        fill(buffer, 20, episode_length=5)
+        assert buffer.steps == 20
+        assert buffer.episodes == 4
+
+    def test_accepts_plain_arrays_and_obs_dicts(self):
+        buffer = make_buffer()
+        buffer.add(np.zeros((3, 8, 8), np.uint8), np.zeros(2, np.float32), 0.0, False)
+        buffer.add({"obs": np.zeros((3, 8, 8), np.uint8)}, np.zeros(2), 0.0, False)
+        assert len(buffer) == 2
+
+    def test_rejects_unknown_observation_keys(self):
+        buffer = make_buffer()
+        with pytest.raises(KeyError, match="image"):
+            buffer.add({"pixels": np.zeros((3, 8, 8))}, np.zeros(2), 0.0, False)
+
+    def test_first_transition_is_marked_as_an_episode_start(self):
+        buffer = make_buffer()
+        fill(buffer, 3)
+        assert buffer.is_first[0] == 1.0
+        assert buffer.is_first[1] == 0.0
+
+    def test_is_first_marks_the_step_after_a_termination(self):
+        buffer = make_buffer()
+        fill(buffer, 10, episode_length=4)
+        # Episode ends at index 3, so index 4 begins a new episode.
+        assert buffer.is_terminal[3] == 1.0
+        assert buffer.is_first[4] == 1.0
+        assert buffer.is_first[3] == 0.0
+
+    def test_time_limit_truncation_is_not_a_termination(self):
+        buffer = make_buffer()
+        buffer.add(
+            {"image": np.zeros((3, 8, 8), np.uint8)},
+            np.zeros(2, np.float32),
+            1.0,
+            done=True,
+            is_terminal=False,
+        )
+        assert buffer.is_terminal[0] == 0.0
+        # The episode still ends, so the next step is a fresh start.
+        buffer.add({"image": np.zeros((3, 8, 8), np.uint8)}, np.zeros(2), 0.0, False)
+        assert buffer.is_first[1] == 1.0
+
+    def test_wraps_around_when_full(self):
+        buffer = make_buffer(size=10)
+        fill(buffer, 25)
+        assert buffer.full
+        assert len(buffer) == 10
+        assert buffer.steps == 25
+
+
+class TestSampling:
+    def test_raises_before_enough_data(self):
+        buffer = make_buffer(seq_len=8)
+        fill(buffer, 4)
+        with pytest.raises(RuntimeError, match="not"):
+            buffer.sample()
+
+    def test_batch_shapes(self):
+        buffer = make_buffer(seq_len=5, batch_size=3)
+        fill(buffer, 40)
+        obs, actions, rewards, terminal, first = buffer.sample()
+        assert obs.shape == (5, 3, 3, 8, 8)
+        assert actions.shape == (5, 3, 2)
+        assert rewards.shape == (5, 3)
+        assert terminal.shape == (5, 3)
+        assert first.shape == (5, 3)
+
+    def test_sequences_are_contiguous_in_time(self):
+        buffer = make_buffer(seq_len=4, batch_size=2)
+        fill(buffer, 40)
+        _, _, rewards, _, _ = buffer.sample()
+        # Rewards were written as the step index, so each column must increase
+        # by exactly one per timestep.
+        deltas = np.diff(rewards, axis=0)
+        assert np.all(deltas == 1.0)
+
+    def test_sequences_may_span_episode_boundaries(self):
+        # DreamerV3 relies on `is_first` rather than rejecting these windows.
+        buffer = make_buffer(seq_len=6, batch_size=8)
+        fill(buffer, 60, episode_length=3)
+        _, _, _, _, first = buffer.sample()
+        assert first.sum() > 0
+
+    def test_samples_stay_within_written_data(self):
+        buffer = make_buffer(size=64, seq_len=4, batch_size=6)
+        fill(buffer, 20)
+        _, _, rewards, _, _ = buffer.sample()
+        assert rewards.max() < 20
+        assert rewards.min() >= 0
+
+    def test_full_buffer_never_reads_the_write_head_gap(self):
+        buffer = make_buffer(size=16, seq_len=4, batch_size=8)
+        fill(buffer, 100)
+        _, _, rewards, _, _ = buffer.sample()
+        # Contiguity is the observable signal that no window wrapped over the
+        # boundary between newest and oldest data.
+        assert np.all(np.diff(rewards, axis=0) == 1.0)
+
+
+class TestOnlineQueue:
+    def test_online_samples_are_preferred_when_available(self):
+        buffer = make_buffer(size=256, seq_len=4, batch_size=4, online_fraction=1.0)
+        fill(buffer, 40)
+        _, _, rewards, _, _ = buffer.sample()
+        # The queue hands out the oldest unconsumed non-overlapping windows,
+        # which start at multiples of seq_len.
+        assert set(rewards[0].tolist()) == {0.0, 4.0, 8.0, 12.0}
+
+    def test_queue_is_consumed_across_batches(self):
+        buffer = make_buffer(size=256, seq_len=4, batch_size=2, online_fraction=1.0)
+        fill(buffer, 40)
+        first_batch = buffer.sample()[2][0]
+        second_batch = buffer.sample()[2][0]
+        assert not set(first_batch.tolist()) & set(second_batch.tolist())
+
+    def test_falls_back_to_uniform_when_the_queue_is_empty(self):
+        buffer = make_buffer(size=256, seq_len=4, batch_size=6, online_fraction=1.0)
+        fill(buffer, 12)
+        obs, _, _, _, _ = buffer.sample()
+        assert obs.shape[1] == 6
+
+    def test_zero_online_fraction_uses_only_uniform_sampling(self):
+        buffer = make_buffer(size=256, seq_len=4, batch_size=4, online_fraction=0.0)
+        fill(buffer, 60)
+        starts = {buffer.sample()[2][0].tolist()[0] for _ in range(10)}
+        assert len(starts) > 1
+
+
+class TestObservationDtypes:
+    def test_float_observations_are_preserved(self):
+        buffer = DreamerV3ReplayBuffer(
+            size=32,
+            obs_shape=(4,),
+            action_size=1,
+            seq_len=3,
+            batch_size=2,
+            obs_dtype=np.float32,
+        )
+        for step in range(10):
+            buffer.add(
+                np.full(4, step * 0.5, dtype=np.float32),
+                np.zeros(1, np.float32),
+                0.0,
+                False,
+            )
+        obs, _, _, _, _ = buffer.sample()
+        assert obs.dtype == np.float32
+        assert np.any(obs % 1.0 != 0.0)

--- a/tests/models/test_categorical_rssm.py
+++ b/tests/models/test_categorical_rssm.py
@@ -1,0 +1,243 @@
+"""Tests for the DreamerV3 categorical RSSM and its block-diagonal GRU."""
+
+import pytest
+import torch
+
+from world_models.layers.block_gru import BlockGRUCell, BlockLinear
+from world_models.models.categorical_rssm import CategoricalRSSM
+
+
+class TestBlockLinear:
+    def test_output_shape(self):
+        layer = BlockLinear(16, 24, blocks=4)
+        assert layer(torch.randn(5, 16)).shape == (5, 24)
+
+    def test_preserves_leading_dimensions(self):
+        layer = BlockLinear(16, 8, blocks=4)
+        assert layer(torch.randn(3, 7, 16)).shape == (3, 7, 8)
+
+    def test_blocks_do_not_mix(self):
+        # The defining property: output block i must be unaffected by input
+        # block j for i != j. Output 0 lives in block 0, which reads inputs 0-1.
+        layer = BlockLinear(8, 8, blocks=4)
+        inputs = torch.zeros(1, 8, requires_grad=True)
+        layer(inputs)[0, 0].backward()
+        grad = inputs.grad
+        assert grad is not None
+        assert float(grad[0, :2].abs().sum()) > 0.0
+        assert torch.equal(grad[0, 2:], torch.zeros(6))
+
+    def test_uses_a_fraction_of_a_dense_layer_s_parameters(self):
+        # This is the point of the block structure: `blocks` times fewer
+        # recurrent weights than a dense layer covering the same units.
+        size, blocks = 64, 8
+        block_layer = BlockLinear(size, size, blocks=blocks)
+        assert block_layer.weight.numel() == size * size // blocks
+        assert block_layer.weight.numel() < torch.nn.Linear(size, size).weight.numel()
+
+    def test_rejects_indivisible_sizes(self):
+        with pytest.raises(ValueError, match="divisible"):
+            BlockLinear(10, 8, blocks=4)
+        with pytest.raises(ValueError, match="divisible"):
+            BlockLinear(8, 10, blocks=4)
+
+
+class TestBlockGRUCell:
+    def test_output_shape(self):
+        cell = BlockGRUCell(32, blocks=4)
+        state = cell(torch.randn(6, 32), torch.zeros(6, 32))
+        assert state.shape == (6, 32)
+
+    def test_is_differentiable(self):
+        cell = BlockGRUCell(16, blocks=4)
+        inputs = torch.randn(2, 16, requires_grad=True)
+        cell(inputs, torch.zeros(2, 16)).sum().backward()
+        assert inputs.grad is not None
+        assert torch.isfinite(inputs.grad).all()
+
+    def test_update_gate_is_biased_towards_retaining_state(self):
+        # With zero input the gate offset should keep most of the prior state.
+        cell = BlockGRUCell(32, blocks=4)
+        previous = torch.ones(1, 32)
+        state = cell(torch.zeros(1, 32), previous)
+        assert float((state - previous).abs().mean()) < 0.5
+
+    def test_rejects_indivisible_hidden_size(self):
+        with pytest.raises(ValueError, match="divisible"):
+            BlockGRUCell(30, blocks=8)
+
+
+@pytest.fixture
+def rssm():
+    return CategoricalRSSM(
+        action_size=3,
+        embed_size=64,
+        latent_dim=8,
+        latent_classes=6,
+        deter_size=32,
+        hidden_size=16,
+        gru_blocks=4,
+    )
+
+
+class TestCategoricalRSSMState:
+    def test_init_state_shapes(self, rssm):
+        state = rssm.init_state(4, torch.device("cpu"))
+        assert state["logit"].shape == (4, 8, 6)
+        assert state["stoch"].shape == (4, 8, 6)
+        assert state["deter"].shape == (4, 32)
+
+    def test_feature_size(self, rssm):
+        assert rssm.feature_size == 8 * 6 + 32
+        state = rssm.init_state(4, torch.device("cpu"))
+        assert rssm.get_feat(state).shape == (4, rssm.feature_size)
+
+    def test_seq_to_batch_flattens_time(self, rssm):
+        state = {
+            "logit": torch.zeros(5, 4, 8, 6),
+            "stoch": torch.zeros(5, 4, 8, 6),
+            "deter": torch.zeros(5, 4, 32),
+        }
+        flat = rssm.seq_to_batch(state)
+        assert flat["deter"].shape == (20, 32)
+        assert flat["stoch"].shape == (20, 8, 6)
+
+
+class TestCategoricalSampling:
+    def test_samples_are_one_hot(self, rssm):
+        logits = torch.randn(7, 8, 6)
+        sample = rssm._sample(logits)
+        assert sample.shape == (7, 8, 6)
+        assert torch.allclose(sample.sum(-1), torch.ones(7, 8), atol=1e-5)
+        # Exactly one entry per categorical is 1 in the forward pass.
+        assert int((sample > 0.99).sum()) == 7 * 8
+
+    def test_straight_through_gradients_reach_the_logits(self, rssm):
+        logits = torch.randn(4, 8, 6, requires_grad=True)
+        rssm._sample(logits).sum().backward()
+        assert logits.grad is not None
+        assert float(logits.grad.abs().sum()) > 0.0
+
+    def test_unimix_bounds_probabilities_away_from_zero(self, rssm):
+        # A hugely peaked logit vector must still leave unimix/classes mass on
+        # every class, which is what keeps the KL terms finite.
+        extreme = torch.zeros(1, 8, 6)
+        extreme[..., 0] = 50.0
+        mixed = rssm._apply_unimix(extreme)
+        probs = torch.softmax(mixed, dim=-1)
+        assert float(probs.min()) >= rssm.unimix / rssm.latent_classes - 1e-6
+
+    def test_unimix_probabilities_still_sum_to_one(self, rssm):
+        mixed = rssm._apply_unimix(torch.randn(3, 8, 6))
+        probs = torch.softmax(mixed, dim=-1)
+        assert torch.allclose(probs.sum(-1), torch.ones(3, 8), atol=1e-5)
+
+    def test_unimix_disabled_is_a_passthrough(self):
+        model = CategoricalRSSM(
+            action_size=2,
+            embed_size=8,
+            latent_dim=2,
+            latent_classes=3,
+            deter_size=8,
+            hidden_size=8,
+            gru_blocks=2,
+            unimix=0.0,
+        )
+        logits = torch.randn(2, 2, 3)
+        assert torch.equal(model._apply_unimix(logits), logits)
+
+
+class TestCategoricalRSSMSteps:
+    def test_imagine_step_shapes(self, rssm):
+        state = rssm.init_state(3, torch.device("cpu"))
+        prior = rssm.imagine_step(state, torch.zeros(3, 3))
+        assert prior["deter"].shape == (3, 32)
+        assert prior["stoch"].shape == (3, 8, 6)
+
+    def test_observe_step_shares_the_deterministic_state(self, rssm):
+        state = rssm.init_state(3, torch.device("cpu"))
+        posterior, prior = rssm.observe_step(
+            state, torch.zeros(3, 3), torch.randn(3, 64)
+        )
+        assert torch.equal(posterior["deter"], prior["deter"])
+
+    def test_posterior_differs_from_prior(self, rssm):
+        state = rssm.init_state(3, torch.device("cpu"))
+        posterior, prior = rssm.observe_step(
+            state, torch.zeros(3, 3), torch.randn(3, 64) * 5
+        )
+        assert not torch.allclose(posterior["logit"], prior["logit"])
+
+    def test_is_first_resets_the_recurrent_state(self, rssm):
+        state = rssm.init_state(2, torch.device("cpu"))
+        state["deter"] = torch.randn(2, 32)
+        state["stoch"] = torch.rand(2, 8, 6)
+        action = torch.randn(2, 3)
+
+        reset = rssm.imagine_step(state, action, torch.ones(2, 1))
+        from_zero = rssm.imagine_step(
+            rssm.init_state(2, torch.device("cpu")),
+            torch.zeros(2, 3),
+            torch.zeros(2, 1),
+        )
+        assert torch.allclose(reset["deter"], from_zero["deter"], atol=1e-6)
+
+    def test_is_first_zero_keeps_history(self, rssm):
+        state = rssm.init_state(2, torch.device("cpu"))
+        state["deter"] = torch.randn(2, 32)
+        kept = rssm.imagine_step(state, torch.zeros(2, 3), torch.zeros(2, 1))
+        reset = rssm.imagine_step(state, torch.zeros(2, 3), torch.ones(2, 1))
+        assert not torch.allclose(kept["deter"], reset["deter"])
+
+
+class TestCategoricalRSSMRollouts:
+    def test_observe_rollout_shapes(self, rssm):
+        seq_len, batch = 5, 3
+        posterior, prior = rssm.observe_rollout(
+            torch.randn(seq_len, batch, 64),
+            torch.zeros(seq_len, batch, 3),
+            torch.zeros(seq_len, batch, 1),
+            rssm.init_state(batch, torch.device("cpu")),
+        )
+        for state in (posterior, prior):
+            assert state["deter"].shape == (seq_len, batch, 32)
+            assert state["logit"].shape == (seq_len, batch, 8, 6)
+
+    def test_imagine_rollout_returns_one_extra_state(self, rssm):
+        start = rssm.init_state(4, torch.device("cpu"))
+        states, actions = rssm.imagine_rollout(
+            lambda feat: torch.zeros(feat.shape[0], 3), start, horizon=6
+        )
+        # horizon + 1 states so the policy can be scored on the start state.
+        assert states["deter"].shape == (7, 4, 32)
+        assert actions.shape == (6, 4, 3)
+
+    def test_imagine_rollout_starts_from_the_given_state(self, rssm):
+        start = rssm.init_state(2, torch.device("cpu"))
+        start["deter"] = torch.randn(2, 32)
+        states, _ = rssm.imagine_rollout(
+            lambda feat: torch.zeros(feat.shape[0], 3), start, horizon=2
+        )
+        assert torch.equal(states["deter"][0], start["deter"])
+
+
+class TestCategoricalKL:
+    def test_kl_of_identical_distributions_is_zero(self, rssm):
+        logits = torch.randn(4, 8, 6)
+        kl = rssm.kl_divergence(logits, logits.clone())
+        assert torch.allclose(kl, torch.zeros(4), atol=1e-5)
+
+    def test_kl_is_non_negative(self, rssm):
+        kl = rssm.kl_divergence(torch.randn(9, 8, 6), torch.randn(9, 8, 6))
+        assert float(kl.min()) >= -1e-5
+
+    def test_kl_shape_sums_over_latent_factors(self, rssm):
+        kl = rssm.kl_divergence(torch.randn(5, 3, 8, 6), torch.randn(5, 3, 8, 6))
+        assert kl.shape == (5, 3)
+
+    def test_detached_argument_blocks_that_gradient_path(self, rssm):
+        posterior = torch.randn(2, 8, 6, requires_grad=True)
+        prior = torch.randn(2, 8, 6, requires_grad=True)
+        rssm.kl_divergence(posterior.detach(), prior).sum().backward()
+        assert posterior.grad is None
+        assert prior.grad is not None

--- a/tests/models/test_dreamer_v3.py
+++ b/tests/models/test_dreamer_v3.py
@@ -1,0 +1,963 @@
+"""Tests for the DreamerV3 agent, its networks, and its public wiring."""
+
+import gc
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pytest
+import torch
+
+from world_models.configs.dreamer_v3_config import MODEL_SIZES, DreamerV3Config
+from world_models.models.dreamer_v3 import (
+    DreamerV3,
+    DreamerV3Agent,
+    _is_true_termination,
+    _resolve_actor_dist,
+    coerce_dreamer_v3_config,
+)
+from world_models.vision.dreamer_v3_nets import (
+    DreamerV3Actor,
+    DreamerV3Decoder,
+    DreamerV3Encoder,
+    DreamerV3Head,
+    preprocess_image,
+)
+
+# Deliberately smaller than the 64x64 the agent uses in practice. Every test here
+# builds a model and a replay buffer, and at 64x64 the accumulated buffers add
+# enough memory pressure to make memory-hungry tests elsewhere in the suite fail.
+# 32x32 still exercises a three-layer convolution stack down to 4x4.
+IMAGE_SHAPE = (3, 32, 32)
+
+
+@pytest.fixture(autouse=True)
+def _release_models():
+    """Free each test's models and replay buffers before the next test runs.
+
+    Every test here builds a full agent with its own replay buffer. Without an
+    explicit collection those accumulate across the module and the extra
+    pressure makes memory-hungry tests elsewhere in the suite fail.
+    """
+    yield
+    gc.collect()
+
+
+def tiny_config(**overrides):
+    """A config small enough to train a few steps inside a unit test."""
+    defaults = dict(
+        model_size="12m",
+        hidden_size=16,
+        recurrent_units=32,
+        cnn_depth=4,
+        latent_classes=4,
+        latent_dim=4,
+        gru_blocks=4,
+        mlp_layers=1,
+        num_buckets=41,
+        batch_size=2,
+        train_seq_len=6,
+        imagine_horizon=3,
+        buffer_size=100,
+        actor_dist="normal",
+        no_gpu=True,
+    )
+    defaults.update(overrides)
+    return DreamerV3Config(**defaults)
+
+
+def build(config=None, obs_shape=IMAGE_SHAPE, action_size=2):
+    return DreamerV3(config or tiny_config(), obs_shape, action_size, "cpu")
+
+
+def fill(model, steps=40, episode_length=13, image=True):
+    for step in range(steps):
+        if image:
+            obs = {"image": np.random.randint(0, 255, IMAGE_SHAPE, dtype=np.uint8)}
+        else:
+            obs = {"obs": np.random.randn(model.obs_shape[0]).astype(np.float32)}
+        if model.discrete_actions:
+            action = np.zeros(model.action_size, np.float32)
+            action[step % model.action_size] = 1.0
+        else:
+            action = np.random.randn(model.action_size).astype(np.float32)
+        model.data_buffer.add(
+            obs, action, float(step % 3), (step + 1) % episode_length == 0
+        )
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+class TestDreamerV3Config:
+    def test_paper_defaults(self):
+        config = DreamerV3Config()
+        assert config.discount == pytest.approx(0.997)
+        assert config.td_lambda == pytest.approx(0.95)
+        assert config.imagine_horizon == 15
+        assert config.actor_entropy == pytest.approx(3e-4)
+        assert config.learning_rate == pytest.approx(4e-5)
+        assert config.free_nats == pytest.approx(1.0)
+        assert (config.beta_pred, config.beta_dyn, config.beta_rep) == (1.0, 1.0, 0.1)
+        assert config.unimix == pytest.approx(0.01)
+        assert config.critic_ema_decay == pytest.approx(0.98)
+        assert config.critic_replay_loss_scale == pytest.approx(0.3)
+        assert (config.batch_size, config.train_seq_len) == (16, 64)
+
+    def test_model_size_presets_are_resolved(self):
+        config = DreamerV3Config(model_size="200m")
+        assert config.hidden_size == 1024
+        assert config.recurrent_units == 8192
+        assert config.cnn_depth == 64
+        assert config.latent_classes == 64
+
+    def test_recurrent_units_are_eight_times_the_model_dimension(self):
+        # Table 3 of the paper labels this column "Recurrent units (8d)", and
+        # every row follows that rule except 12M, which the table lists as 1024
+        # rather than 2048. The presets reproduce the table verbatim, so 12M is
+        # excluded here rather than silently "corrected".
+        for name, preset in MODEL_SIZES.items():
+            if name == "12m":
+                continue
+            assert preset["recurrent_units"] == 8 * preset["hidden_size"]
+
+    def test_every_preset_is_divisible_by_the_block_count(self):
+        for preset in MODEL_SIZES.values():
+            assert preset["recurrent_units"] % 8 == 0
+
+    def test_widths_increase_monotonically_with_size(self):
+        ordered = [
+            MODEL_SIZES[name] for name in ("12m", "25m", "50m", "100m", "200m", "400m")
+        ]
+        for field in ("hidden_size", "recurrent_units", "cnn_depth", "latent_classes"):
+            values = [preset[field] for preset in ordered]
+            assert values == sorted(values)
+
+    def test_explicit_widths_override_the_preset(self):
+        config = DreamerV3Config(model_size="200m", hidden_size=123)
+        assert config.hidden_size == 123
+        assert config.recurrent_units == 8192
+
+    def test_unknown_model_size_is_rejected(self):
+        with pytest.raises(ValueError, match="model_size"):
+            DreamerV3Config(model_size="7b")
+
+    def test_indivisible_recurrent_units_are_rejected(self):
+        with pytest.raises(ValueError, match="divisible"):
+            DreamerV3Config(recurrent_units=100, gru_blocks=8)
+
+    def test_update_steps_follow_the_replay_ratio(self):
+        config = DreamerV3Config(
+            replay_ratio=32, collect_steps=1000, batch_size=16, train_seq_len=64
+        )
+        assert config.update_steps == 31
+
+    def test_auto_update_steps_can_be_disabled(self):
+        config = DreamerV3Config(auto_update_steps=False, update_steps=7)
+        assert config.update_steps == 7
+
+    def test_inherits_environment_fields(self):
+        config = DreamerV3Config(env="walker-walk", env_backend="dmc")
+        assert config.env == "walker-walk"
+        assert config.image_size == (64, 64)
+
+    def test_yaml_roundtrip(self, tmp_path):
+        config = DreamerV3Config(model_size="50m", seed=11)
+        path = tmp_path / "config.yaml"
+        config.to_yaml(path)
+        restored = DreamerV3Config.from_yaml(path)
+        assert restored.model_size == "50m"
+        assert restored.seed == 11
+        assert restored.hidden_size == 512
+
+    def test_coercion_accepts_dicts_and_none(self):
+        assert isinstance(coerce_dreamer_v3_config(None), DreamerV3Config)
+        assert coerce_dreamer_v3_config({"seed": 3}).seed == 3
+        with pytest.raises(TypeError):
+            coerce_dreamer_v3_config(42)
+
+
+# ---------------------------------------------------------------------------
+# Networks
+# ---------------------------------------------------------------------------
+
+
+class TestNetworks:
+    def test_preprocess_image_maps_to_unit_range(self):
+        raw = torch.tensor([[0, 128, 255]], dtype=torch.uint8)
+        processed = preprocess_image(raw)
+        assert float(processed.min()) == 0.0
+        assert float(processed.max()) == 1.0
+
+    def test_image_encoder_reduces_to_a_small_resolution(self):
+        encoder = DreamerV3Encoder(IMAGE_SHAPE, cnn_depth=8)
+        assert encoder.resolutions[-1] == (4, 4)
+        assert encoder(torch.rand(5, *IMAGE_SHAPE)).shape == (5, encoder.embed_size)
+
+    def test_encoder_preserves_leading_dimensions(self):
+        encoder = DreamerV3Encoder(IMAGE_SHAPE, cnn_depth=4)
+        embedded = encoder(torch.rand(7, 3, *IMAGE_SHAPE))
+        assert embedded.shape == (7, 3, encoder.embed_size)
+
+    def test_standard_64x64_input_uses_four_convolutions(self):
+        # The resolution the agent actually runs at. Kept explicit because the
+        # rest of this module uses 32x32 to stay light on memory.
+        shape = (3, 64, 64)
+        encoder = DreamerV3Encoder(shape, cnn_depth=8)
+        assert encoder.resolutions == [(64, 64), (32, 32), (16, 16), (8, 8), (4, 4)]
+        assert encoder.out_channels == 8 * 2**3
+        assert encoder.embed_size == encoder.out_channels * 4 * 4
+
+    def test_standard_64x64_decoder_inverts_the_encoder(self):
+        shape = (3, 64, 64)
+        encoder = DreamerV3Encoder(shape, cnn_depth=8)
+        decoder = DreamerV3Decoder(24, shape, encoder=encoder, cnn_depth=8)
+        assert decoder(torch.randn(2, 24)).shape == (2, *shape)
+
+    def test_vector_encoder_uses_an_mlp(self):
+        encoder = DreamerV3Encoder((11,), hidden_size=24, mlp_layers=2)
+        assert not encoder.is_image
+        assert encoder(torch.randn(4, 11)).shape == (4, 24)
+
+    def test_decoder_reconstructs_the_input_shape(self):
+        encoder = DreamerV3Encoder(IMAGE_SHAPE, cnn_depth=8)
+        decoder = DreamerV3Decoder(32, IMAGE_SHAPE, encoder=encoder, cnn_depth=8)
+        assert decoder(torch.randn(5, 32)).shape == (5, *IMAGE_SHAPE)
+
+    def test_decoder_output_is_in_the_unit_range(self):
+        encoder = DreamerV3Encoder(IMAGE_SHAPE, cnn_depth=4)
+        decoder = DreamerV3Decoder(16, IMAGE_SHAPE, encoder=encoder, cnn_depth=4)
+        output = decoder(torch.randn(3, 16) * 10)
+        assert float(output.min()) >= 0.0 and float(output.max()) <= 1.0
+
+    def test_decoder_handles_odd_image_sizes(self):
+        shape = (3, 63, 65)
+        encoder = DreamerV3Encoder(shape, cnn_depth=4)
+        decoder = DreamerV3Decoder(16, shape, encoder=encoder, cnn_depth=4)
+        assert decoder(torch.randn(2, 16)).shape == (2, *shape)
+
+    def test_image_decoder_requires_an_encoder(self):
+        with pytest.raises(ValueError, match="image encoder"):
+            DreamerV3Decoder(16, IMAGE_SHAPE)
+
+    def test_decoder_loss_is_zero_for_a_perfect_reconstruction(self):
+        decoder = DreamerV3Decoder(8, (5,), hidden_size=8, mlp_layers=1)
+        target = torch.zeros(3, 5)
+        assert float(decoder.loss(target, target).sum()) == pytest.approx(0.0)
+
+    def test_vector_decoder_loss_uses_symlog_targets(self):
+        # A huge target must not produce a huge loss, which is the point of the
+        # symlog transform on vector observations.
+        decoder = DreamerV3Decoder(8, (2,), hidden_size=8, mlp_layers=1)
+        prediction = torch.zeros(1, 2)
+        assert float(decoder.loss(prediction, torch.full((1, 2), 1e6)).sum()) < 500
+
+    def test_twohot_head_starts_at_zero(self):
+        # Zero-initialized output weights mean the head predicts exactly zero
+        # regardless of its input, so the agent cannot hallucinate rewards or
+        # values before it has learned anything.
+        head = DreamerV3Head(12, layers=1, units=8, num_bins=41)
+        prediction = head(torch.randn(6, 12)).mean
+        assert torch.allclose(prediction, torch.zeros(6), atol=1e-6)
+
+    def test_twohot_head_zero_init_holds_for_the_default_bin_count(self):
+        head = DreamerV3Head(12, layers=1, units=8, num_bins=255, symlog_range=20.0)
+        assert torch.allclose(head(torch.randn(4, 12)).mean, torch.zeros(4), atol=1e-6)
+
+    def test_head_zero_init_can_be_disabled(self):
+        head = DreamerV3Head(12, layers=1, units=8, num_bins=41, zero_init_output=False)
+        assert float(head.model[-1].weight.abs().sum()) > 0.0
+
+    def test_binary_head_returns_a_bernoulli(self):
+        head = DreamerV3Head(12, layers=1, units=8, dist="binary")
+        dist = head(torch.randn(4, 12))
+        assert dist.log_prob(torch.ones(4)).shape == (4,)
+
+    def test_unknown_head_distribution_is_rejected(self):
+        with pytest.raises(ValueError, match="distribution"):
+            DreamerV3Head(4, layers=1, units=4, dist="poisson")(torch.randn(2, 4))
+
+
+class TestActor:
+    def test_continuous_actions_have_the_right_shape(self):
+        actor = DreamerV3Actor(12, 4, discrete=False, layers=1, units=8)
+        assert actor(torch.randn(5, 12)).shape == (5, 4)
+
+    def test_continuous_log_prob_and_entropy_are_per_sample(self):
+        actor = DreamerV3Actor(12, 4, discrete=False, layers=1, units=8)
+        dist = actor.dist(torch.randn(5, 12))
+        action = dist.sample()
+        assert dist.log_prob(action).shape == (5,)
+        assert dist.entropy().shape == (5,)
+
+    def test_continuous_mean_is_bounded(self):
+        actor = DreamerV3Actor(12, 3, discrete=False, layers=1, units=8)
+        mean = actor.dist(torch.randn(20, 12) * 50).mean
+        assert float(mean.abs().max()) <= 1.0
+
+    def test_continuous_std_respects_its_bounds(self):
+        actor = DreamerV3Actor(
+            12, 3, discrete=False, layers=1, units=8, min_std=0.1, max_std=1.0
+        )
+        dist = actor.dist(torch.randn(50, 12) * 50)
+        std = dist.base_dist.scale
+        assert float(std.min()) >= 0.1 - 1e-6
+        assert float(std.max()) <= 1.0 + 1e-6
+
+    def test_discrete_actions_are_one_hot(self):
+        actor = DreamerV3Actor(12, 5, discrete=True, layers=1, units=8)
+        action = actor(torch.randn(7, 12))
+        assert action.shape == (7, 5)
+        assert torch.allclose(action.sum(-1), torch.ones(7))
+
+    def test_discrete_deterministic_takes_the_argmax(self):
+        actor = DreamerV3Actor(12, 5, discrete=True, layers=1, units=8)
+        features = torch.randn(1, 12)
+        repeated = [actor(features, deterministic=True) for _ in range(5)]
+        assert all(torch.equal(repeated[0], other) for other in repeated[1:])
+
+    def test_discrete_unimix_keeps_log_probs_finite(self):
+        actor = DreamerV3Actor(12, 4, discrete=True, layers=1, units=8, unimix=0.01)
+        dist = actor.dist(torch.randn(3, 12) * 100)
+        every_action = torch.eye(4).unsqueeze(1).expand(4, 3, 4)
+        assert torch.isfinite(dist.log_prob(every_action)).all()
+
+    def test_exploration_noise_is_off_by_default(self):
+        actor = DreamerV3Actor(12, 3, discrete=False, layers=1, units=8)
+        action = torch.zeros(2, 3)
+        assert torch.equal(actor.add_exploration(action), action)
+
+    def test_exploration_noise_is_clipped_to_the_action_range(self):
+        actor = DreamerV3Actor(12, 3, discrete=False, layers=1, units=8)
+        noisy = actor.add_exploration(torch.zeros(100, 3), action_noise=10.0)
+        assert float(noisy.abs().max()) <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Core agent
+# ---------------------------------------------------------------------------
+
+
+class TestDreamerV3Core:
+    def test_builds_all_modules(self):
+        model = build()
+        summary = model.summary()
+        assert set(summary["modules"]) == {
+            "rssm",
+            "obs_encoder",
+            "obs_decoder",
+            "reward_model",
+            "continue_model",
+            "value_model",
+            "actor",
+        }
+        assert model.parameter_count() > 0
+
+    def test_slow_critic_starts_identical_and_is_frozen(self):
+        model = build()
+        for slow, fast in zip(
+            model.slow_value_model.parameters(), model.value_model.parameters()
+        ):
+            assert torch.equal(slow, fast)
+            assert not slow.requires_grad
+
+    def test_world_model_loss_is_finite(self):
+        model = build()
+        fill(model)
+        obs, actions, rewards, terminal, first = model.data_buffer.sample()
+        loss, posterior = model.world_model_loss(
+            torch.as_tensor(obs),
+            torch.as_tensor(actions),
+            torch.as_tensor(rewards),
+            torch.as_tensor(terminal),
+            torch.as_tensor(first),
+        )
+        assert torch.isfinite(loss)
+        assert posterior["deter"].shape[0] == model.args.train_seq_len
+
+    def test_train_one_batch_returns_three_finite_losses(self):
+        model = build()
+        fill(model)
+        losses = model.train_one_batch()
+        assert len(losses) == 3
+        assert all(np.isfinite(value) for value in losses)
+
+    def test_train_one_batch_is_a_no_op_on_an_empty_buffer(self):
+        assert build().train_one_batch() == [0.0, 0.0, 0.0]
+
+    def test_reinforce_increases_the_probability_of_good_actions(self):
+        # Guards the sign of the actor objective. With a fixed state and a
+        # constant positive advantage for action 0, Reinforce must make the
+        # policy more likely to pick action 0.
+        config = tiny_config(actor_dist="onehot", actor_entropy=0.0)
+        model = DreamerV3(config, IMAGE_SHAPE, 3, "cpu")
+        horizon, batch = config.imagine_horizon, 8
+
+        features = torch.zeros(horizon + 1, batch, model.rssm.feature_size)
+        actions = torch.zeros(horizon, batch, 3)
+        actions[..., 0] = 1.0
+        imagined = {
+            "features": features,
+            "actions": actions,
+            "returns": torch.ones(horizon, batch),
+            "values": torch.zeros(horizon + 1, batch),
+            "weights": torch.ones(horizon, batch),
+            "rewards": torch.ones(horizon + 1, batch),
+        }
+
+        with torch.no_grad():
+            before = model.actor.dist(features[0]).probs[0, 0].item()
+        for _ in range(20):
+            loss = model.actor_loss(imagined)
+            model._optimize(
+                loss,
+                model.actor_opt,
+                model.actor_scaler,
+                list(model.actor.parameters()),
+                "actor",
+            )
+        with torch.no_grad():
+            after = model.actor.dist(features[0]).probs[0, 0].item()
+
+        assert after > before
+
+    def test_reinforce_decreases_the_probability_of_bad_actions(self):
+        config = tiny_config(actor_dist="onehot", actor_entropy=0.0)
+        model = DreamerV3(config, IMAGE_SHAPE, 3, "cpu")
+        horizon, batch = config.imagine_horizon, 8
+
+        features = torch.zeros(horizon + 1, batch, model.rssm.feature_size)
+        actions = torch.zeros(horizon, batch, 3)
+        actions[..., 0] = 1.0
+        imagined = {
+            "features": features,
+            "actions": actions,
+            # Negative advantage: the taken action was worse than the value.
+            "returns": torch.zeros(horizon, batch),
+            "values": torch.ones(horizon + 1, batch),
+            "weights": torch.ones(horizon, batch),
+            "rewards": torch.zeros(horizon + 1, batch),
+        }
+
+        with torch.no_grad():
+            before = model.actor.dist(features[0]).probs[0, 0].item()
+        for _ in range(20):
+            loss = model.actor_loss(imagined)
+            model._optimize(
+                loss,
+                model.actor_opt,
+                model.actor_scaler,
+                list(model.actor.parameters()),
+                "actor",
+            )
+        with torch.no_grad():
+            after = model.actor.dist(features[0]).probs[0, 0].item()
+
+        assert after < before
+
+    def test_entropy_bonus_pushes_the_policy_towards_uniform(self):
+        # With no advantage signal, the entropy term alone should flatten a
+        # policy that starts out peaked.
+        config = tiny_config(actor_dist="onehot", actor_entropy=1.0)
+        model = DreamerV3(config, IMAGE_SHAPE, 4, "cpu")
+        horizon, batch = config.imagine_horizon, 4
+
+        features = torch.randn(horizon + 1, batch, model.rssm.feature_size)
+        actions = torch.zeros(horizon, batch, 4)
+        actions[..., 0] = 1.0
+        imagined = {
+            "features": features,
+            "actions": actions,
+            "returns": torch.zeros(horizon, batch),
+            "values": torch.zeros(horizon + 1, batch),
+            "weights": torch.ones(horizon, batch),
+            "rewards": torch.zeros(horizon + 1, batch),
+        }
+
+        with torch.no_grad():
+            before = model.actor.dist(features[0]).entropy().mean().item()
+        for _ in range(30):
+            loss = model.actor_loss(imagined)
+            model._optimize(
+                loss,
+                model.actor_opt,
+                model.actor_scaler,
+                list(model.actor.parameters()),
+                "actor",
+            )
+        with torch.no_grad():
+            after = model.actor.dist(features[0]).entropy().mean().item()
+
+        assert after >= before
+
+    def test_critic_learns_to_predict_its_targets(self):
+        # The critic loss must actually move predictions towards the returns.
+        model = build()
+        fill(model)
+        obs, actions, rewards, terminal, first = model.data_buffer.sample()
+        _, posterior = model.world_model_loss(
+            torch.as_tensor(obs),
+            torch.as_tensor(actions),
+            torch.as_tensor(rewards),
+            torch.as_tensor(terminal),
+            torch.as_tensor(first),
+        )
+        imagined = model._imagine(posterior)
+        imagined["returns"] = torch.full_like(imagined["returns"], 5.0)
+
+        def error():
+            with torch.no_grad():
+                predicted = model.value_model(imagined["features"][:-1]).mean
+            return float((predicted - 5.0).abs().mean())
+
+        before = error()
+        for _ in range(30):
+            loss = model.value_loss(imagined)
+            model._optimize(
+                loss,
+                model.value_opt,
+                model.value_scaler,
+                list(model.value_model.parameters()),
+                "critic",
+            )
+        assert error() < before
+
+    def test_training_updates_every_component(self):
+        model = build()
+        fill(model)
+        before = {
+            name: [param.detach().clone() for param in module.parameters()]
+            for name, module in model._named_modules().items()
+        }
+        for _ in range(3):
+            model.train_one_batch()
+        for name, module in model._named_modules().items():
+            changed = any(
+                not torch.equal(old, new)
+                for old, new in zip(before[name], module.parameters())
+            )
+            assert changed, f"{name} did not update"
+
+    def test_slow_critic_tracks_the_critic_without_matching_it(self):
+        model = build()
+        fill(model)
+        for _ in range(3):
+            model.train_one_batch()
+        slow = torch.cat([p.flatten() for p in model.slow_value_model.parameters()])
+        fast = torch.cat([p.flatten() for p in model.value_model.parameters()])
+        assert not torch.equal(slow, fast)
+        assert torch.isfinite(slow).all()
+
+    def test_metrics_are_published_for_logging(self):
+        model = build()
+        fill(model)
+        model.train_one_batch()
+        for key in (
+            "wm/recon_loss",
+            "wm/dyn_loss",
+            "wm/rep_loss",
+            "actor/entropy",
+            "actor/return_scale",
+            "grad_norm/world_model",
+        ):
+            assert key in model.last_metrics
+
+    def test_replay_critic_loss_can_be_disabled(self):
+        model = build(tiny_config(critic_replay_loss_scale=0.0))
+        fill(model)
+        model.train_one_batch()
+        assert "critic/replay_loss" not in model.last_metrics
+
+    def test_discrete_action_training(self):
+        config = tiny_config(actor_dist="onehot")
+        model = DreamerV3(config, IMAGE_SHAPE, 4, "cpu")
+        assert model.discrete_actions
+        fill(model)
+        assert all(np.isfinite(value) for value in model.train_one_batch())
+
+    def test_vector_observation_training(self):
+        model = DreamerV3(tiny_config(), (9,), 2, "cpu")
+        assert not model.is_image_obs
+        assert model.data_buffer.observations.dtype == np.float32
+        fill(model, image=False)
+        assert all(np.isfinite(value) for value in model.train_one_batch())
+
+    def test_imagination_shapes(self):
+        model = build()
+        fill(model)
+        obs, actions, rewards, terminal, first = model.data_buffer.sample()
+        _, posterior = model.world_model_loss(
+            torch.as_tensor(obs),
+            torch.as_tensor(actions),
+            torch.as_tensor(rewards),
+            torch.as_tensor(terminal),
+            torch.as_tensor(first),
+        )
+        imagined = model._imagine(posterior)
+        horizon = model.args.imagine_horizon
+        flat = model.args.train_seq_len * model.args.batch_size
+        assert imagined["features"].shape == (
+            horizon + 1,
+            flat,
+            model.rssm.feature_size,
+        )
+        assert imagined["returns"].shape == (horizon, flat)
+        assert imagined["weights"].shape == (horizon, flat)
+
+    def test_imagination_weights_start_at_one_and_decay(self):
+        model = build()
+        fill(model)
+        obs, actions, rewards, terminal, first = model.data_buffer.sample()
+        _, posterior = model.world_model_loss(
+            torch.as_tensor(obs),
+            torch.as_tensor(actions),
+            torch.as_tensor(rewards),
+            torch.as_tensor(terminal),
+            torch.as_tensor(first),
+        )
+        weights = model._imagine(posterior)["weights"]
+        assert torch.allclose(weights[0], torch.ones_like(weights[0]))
+        assert float(weights[-1].max()) <= 1.0
+
+    def test_imagined_return_credits_the_state_that_was_acted_from(self):
+        # Pins the reward/state alignment. The reward head is trained so that
+        # its prediction at a state is the reward for *leaving* that state, so
+        # the return at s_0 must include the reward predicted at s_0. Consuming
+        # rewards[1:] instead would drop it and shift all credit by one step.
+        model = build(tiny_config(discount=1.0, td_lambda=1.0, actor_entropy=0.0))
+        horizon = model.args.imagine_horizon
+
+        # A reward head that always predicts 1, a critic that always predicts 0,
+        # and no termination make the exact return analytically known.
+        rewards = torch.ones(horizon + 1, 4)
+        values = torch.zeros(horizon + 1, 4)
+        continues = torch.ones(horizon + 1, 4)
+
+        from world_models.utils.dreamer_v3_utils import lambda_return
+
+        returns = lambda_return(
+            rewards=rewards[:-1],
+            values=values[1:],
+            continues=continues[:-1],
+            bootstrap=values[-1],
+            lambda_=1.0,
+        )
+        # Undiscounted sum of the `horizon` rewards collected from s_0 onwards.
+        assert float(returns[0, 0]) == pytest.approx(float(horizon))
+        # And one fewer reward remains from the next state.
+        assert float(returns[1, 0]) == pytest.approx(float(horizon - 1))
+
+    def test_imagined_returns_grow_with_predicted_reward(self):
+        model = build()
+        fill(model)
+        obs, actions, rewards, terminal, first = model.data_buffer.sample()
+        _, posterior = model.world_model_loss(
+            torch.as_tensor(obs),
+            torch.as_tensor(actions),
+            torch.as_tensor(rewards),
+            torch.as_tensor(terminal),
+            torch.as_tensor(first),
+        )
+        imagined = model._imagine(posterior)
+        # Returns accumulate several imagined rewards, so with non-negative
+        # rewards they must not be smaller than a single step's reward.
+        assert (
+            float(imagined["returns"].mean())
+            >= float(imagined["rewards"][:-1].mean()) - 1e-3
+        )
+
+
+class TestCheckpointing:
+    def test_save_and_restore_roundtrip(self, tmp_path):
+        model = build()
+        fill(model)
+        for _ in range(2):
+            model.train_one_batch()
+        path = tmp_path / "model.pt"
+        model.save(str(path))
+
+        restored = build()
+        restored.restore_checkpoint(str(path))
+        for name, module in model._named_modules().items():
+            for original, loaded in zip(
+                module.parameters(), restored._named_modules()[name].parameters()
+            ):
+                assert torch.equal(original, loaded), name
+
+    def test_save_writes_a_config_beside_the_checkpoint(self, tmp_path):
+        model = build()
+        model.save(str(tmp_path / "model.pt"))
+        assert (tmp_path / "config.yaml").exists()
+
+    def test_return_normalizer_state_survives_a_roundtrip(self, tmp_path):
+        model = build()
+        fill(model)
+        model.train_one_batch()
+        path = tmp_path / "model.pt"
+        model.save(str(path))
+
+        restored = build()
+        restored.restore_checkpoint(str(path))
+        assert restored.return_norm.scale == pytest.approx(model.return_norm.scale)
+
+    def test_from_pretrained_rebuilds_the_model(self, tmp_path):
+        model = build()
+        fill(model)
+        model.train_one_batch()
+        model.save(str(tmp_path / "model.pt"))
+
+        loaded = DreamerV3.from_pretrained(tmp_path, map_location="cpu")
+        assert loaded.obs_shape == model.obs_shape
+        assert loaded.action_size == model.action_size
+        assert torch.equal(
+            next(loaded.actor.parameters()), next(model.actor.parameters())
+        )
+
+    def test_from_pretrained_reports_a_missing_checkpoint(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            DreamerV3.from_pretrained(tmp_path / "nothing-here")
+
+
+# ---------------------------------------------------------------------------
+# Environment interaction
+# ---------------------------------------------------------------------------
+
+
+class FakeEnv:
+    """Minimal image environment with the TorchWM four-tuple step API."""
+
+    def __init__(self, action_size=2, episode_length=5, discrete=False):
+        self.action_size = action_size
+        self.episode_length = episode_length
+        self.discrete = discrete
+        self.steps = 0
+        self.action_space = Mock()
+        self.action_space.shape = (action_size,)
+        self.action_space.sample = self._sample
+
+    def _sample(self):
+        if self.discrete:
+            action = np.zeros(self.action_size, np.float32)
+            action[np.random.randint(self.action_size)] = 1.0
+            return action
+        return np.random.uniform(-1, 1, self.action_size).astype(np.float32)
+
+    def _obs(self):
+        return {"image": np.random.randint(0, 255, IMAGE_SHAPE, dtype=np.uint8)}
+
+    def reset(self):
+        self.steps = 0
+        return self._obs()
+
+    def step(self, action):
+        self.steps += 1
+        done = self.steps % self.episode_length == 0
+        return self._obs(), 1.0, done, {"action": np.asarray(action)}
+
+
+class TestInteraction:
+    def test_collect_random_episodes_fills_the_buffer(self):
+        model = build()
+        rewards = model.collect_random_episodes(FakeEnv(), 20)
+        assert model.data_buffer.steps == 20
+        assert len(rewards) > 1
+
+    def test_act_and_collect_data_fills_the_buffer(self):
+        model = build()
+        rewards = model.act_and_collect_data(FakeEnv(), 15)
+        assert model.data_buffer.steps == 15
+        assert np.all(rewards > 0)
+
+    def test_episode_starts_are_recorded_during_collection(self):
+        model = build()
+        model.act_and_collect_data(FakeEnv(episode_length=4), 16)
+        assert model.data_buffer.is_first[:16].sum() >= 3
+
+    def test_evaluate_returns_rewards_and_frames(self):
+        model = build()
+        rewards, videos, latents = model.evaluate(FakeEnv(), 2, render=True)
+        assert rewards.shape == (2,)
+        assert len(videos) > 0
+        assert latents is not None
+
+    def test_greedy_action_is_deterministic_given_the_model_state(self):
+        # Note the qualifier: evaluation is greedy in the *policy*, but the
+        # latent posterior is still sampled, so repeating an observation does
+        # not reproduce an action. Determinism holds once the state is fixed.
+        model = build()
+        features = torch.randn(1, model.rssm.feature_size)
+        with torch.no_grad():
+            actions = [model.actor(features, deterministic=True) for _ in range(5)]
+        assert all(torch.equal(actions[0], other) for other in actions[1:])
+
+    def test_repeated_observations_differ_because_the_latent_is_sampled(self):
+        model = build()
+        obs = {"image": np.zeros(IMAGE_SHAPE, dtype=np.uint8)}
+        state = model.rssm.init_state(1, model.device)
+        action = torch.zeros(1, model.action_size)
+        with torch.no_grad():
+            states = [
+                model.act_with_world_model(obs, state, action)[0]["stoch"]
+                for _ in range(10)
+            ]
+        assert any(not torch.equal(states[0], other) for other in states[1:])
+
+    def test_exploration_sampling_varies(self):
+        model = build()
+        obs = {"image": np.zeros(IMAGE_SHAPE, dtype=np.uint8)}
+        state = model.rssm.init_state(1, model.device)
+        action = torch.zeros(1, model.action_size)
+        with torch.no_grad():
+            samples = [
+                model.act_with_world_model(obs, state, action, explore=True)[1]
+                for _ in range(8)
+            ]
+        assert any(not torch.allclose(samples[0], other) for other in samples[1:])
+
+
+class TestTerminationDetection:
+    def test_not_done_is_not_terminal(self):
+        assert _is_true_termination({}, False) == 0.0
+
+    def test_plain_done_is_terminal(self):
+        assert _is_true_termination({}, True) == 1.0
+
+    def test_time_limit_truncation_is_not_terminal(self):
+        assert _is_true_termination({"time_limit": True}, True) == 0.0
+        assert _is_true_termination({"TimeLimit.truncated": True}, True) == 0.0
+
+    def test_dm_control_discount_marks_truncation(self):
+        assert _is_true_termination({"discount": 1.0}, True) == 0.0
+        assert _is_true_termination({"discount": 0.0}, True) == 1.0
+
+    def test_non_dict_info_falls_back_to_done(self):
+        assert _is_true_termination(None, True) == 1.0
+
+
+class TestActorDistResolution:
+    def test_box_action_space_resolves_to_normal(self):
+        env = Mock()
+        env.action_space = Mock(spec=["shape", "low", "high"])
+        env._env = None
+        assert _resolve_actor_dist(env) == "normal"
+
+    def test_discrete_action_space_resolves_to_onehot(self):
+        env = Mock()
+        env.action_space = Mock(spec=["n"])
+        assert _resolve_actor_dist(env) == "onehot"
+
+    def test_one_hot_wrapped_env_resolves_to_onehot(self):
+        inner = Mock()
+        inner.action_space = Mock(spec=["n"])
+        env = Mock()
+        env.action_space = Mock(spec=["shape", "low", "high"])
+        env._env = inner
+        assert _resolve_actor_dist(env) == "onehot"
+
+
+# ---------------------------------------------------------------------------
+# High-level agent and public API
+# ---------------------------------------------------------------------------
+
+
+class TestDreamerV3Agent:
+    @patch("world_models.models.dreamer.make_env")
+    @patch("world_models.models.dreamer.Logger")
+    def test_builds_a_v3_core_and_config(self, _logger, mock_make_env, tmp_path):
+        env = FakeEnv()
+        env.observation_space = {"image": Mock(shape=IMAGE_SHAPE)}
+        env.action_space.low = -np.ones(2)
+        env.action_space.high = np.ones(2)
+        mock_make_env.return_value = env
+
+        agent = DreamerV3Agent(tiny_config(data_dir=str(tmp_path)))
+        assert isinstance(agent.dreamer, DreamerV3)
+        assert isinstance(agent.args, DreamerV3Config)
+
+    @patch("world_models.models.dreamer.make_env")
+    @patch("world_models.models.dreamer.Logger")
+    def test_resolves_the_actor_distribution_from_the_env(
+        self, _logger, mock_make_env, tmp_path
+    ):
+        env = FakeEnv(discrete=True)
+        env.observation_space = {"image": Mock(shape=IMAGE_SHAPE)}
+        env.action_space = Mock(spec=["shape", "n", "sample"])
+        env.action_space.shape = (2,)
+        env.action_space.n = 2
+        env.action_space.sample = env._sample
+        mock_make_env.return_value = env
+
+        agent = DreamerV3Agent(tiny_config(actor_dist="auto", data_dir=str(tmp_path)))
+        assert agent.args.actor_dist == "onehot"
+        assert agent.dreamer.discrete_actions
+
+    @patch("world_models.models.dreamer.make_env")
+    @patch("world_models.models.dreamer.Logger")
+    def test_upgrades_a_base_dreamer_config(self, _logger, mock_make_env, tmp_path):
+        from world_models.configs.dreamer_config import DreamerConfig
+
+        env = FakeEnv()
+        env.observation_space = {"image": Mock(shape=IMAGE_SHAPE)}
+        env.action_space.low = -np.ones(2)
+        env.action_space.high = np.ones(2)
+        mock_make_env.return_value = env
+
+        base = DreamerConfig(seed=99, buffer_size=100, data_dir=str(tmp_path))
+        agent = DreamerV3Agent(base)
+        assert isinstance(agent.args, DreamerV3Config)
+        # Explicitly changed fields carry over ...
+        assert agent.args.seed == 99
+        # ... but fields left at the base defaults must not clobber V3's own
+        # tuned values, or the agent would quietly train with V1 settings.
+        assert agent.args.discount == pytest.approx(0.997)
+        assert agent.args.batch_size == 16
+
+    @patch("world_models.models.dreamer.make_env")
+    @patch("world_models.models.dreamer.Logger")
+    def test_explicit_base_config_overrides_are_respected(
+        self, _logger, mock_make_env, tmp_path
+    ):
+        from world_models.configs.dreamer_config import DreamerConfig
+
+        env = FakeEnv()
+        env.observation_space = {"image": Mock(shape=IMAGE_SHAPE)}
+        env.action_space.low = -np.ones(2)
+        env.action_space.high = np.ones(2)
+        mock_make_env.return_value = env
+
+        base = DreamerConfig(
+            discount=0.5, batch_size=3, buffer_size=100, data_dir=str(tmp_path)
+        )
+        agent = DreamerV3Agent(base)
+        assert agent.args.discount == pytest.approx(0.5)
+        assert agent.args.batch_size == 3
+
+
+class TestPublicApi:
+    def test_registered_under_both_names(self):
+        from world_models.api import get_model_spec
+
+        for name in ("dreamer-v3", "dreamerv3"):
+            spec = get_model_spec(name)
+            assert spec.import_path.endswith("DreamerV3Agent")
+            assert spec.config_path.endswith("DreamerV3Config")
+
+    def test_create_config_returns_a_v3_config(self):
+        from world_models.api import create_config
+
+        config = create_config("dreamer-v3", seed=5)
+        assert isinstance(config, DreamerV3Config)
+        assert config.seed == 5
+
+    def test_exported_from_the_package_root(self):
+        import world_models
+
+        assert world_models.DreamerV3 is DreamerV3
+        assert world_models.DreamerV3Agent is DreamerV3Agent
+        assert world_models.DreamerV3Config is DreamerV3Config
+
+    def test_listed_in_the_environment_catalog(self):
+        from world_models.api import list_envs
+
+        assert len(list_envs("dreamerv3")) > 0

--- a/tests/optim/test_laprop.py
+++ b/tests/optim/test_laprop.py
@@ -1,0 +1,148 @@
+"""Tests for the LaProp optimizer and adaptive gradient clipping."""
+
+import pytest
+import torch
+
+from world_models.optim import LaProp, adaptive_grad_clip_
+
+
+class TestAdaptiveGradClip:
+    def test_leaves_small_gradients_untouched(self):
+        param = torch.nn.Parameter(torch.ones(10))  # norm sqrt(10) ~ 3.16
+        param.grad = torch.full((10,), 0.001)
+        before = param.grad.clone()
+        adaptive_grad_clip_([param], clip=0.3)
+        assert torch.equal(param.grad, before)
+
+    def test_clips_large_gradients_to_the_threshold(self):
+        param = torch.nn.Parameter(torch.ones(4))  # norm 2.0
+        param.grad = torch.full((4,), 100.0)
+        adaptive_grad_clip_([param], clip=0.3)
+        assert float(param.grad.norm()) == pytest.approx(0.3 * 2.0, rel=1e-4)
+
+    def test_clipping_preserves_gradient_direction(self):
+        param = torch.nn.Parameter(torch.ones(3))
+        param.grad = torch.tensor([3.0, 6.0, 9.0])
+        adaptive_grad_clip_([param], clip=0.1)
+        normalized = param.grad / param.grad.norm()
+        expected = torch.tensor([3.0, 6.0, 9.0])
+        expected = expected / expected.norm()
+        assert torch.allclose(normalized, expected, atol=1e-5)
+
+    def test_threshold_scales_with_the_weight_norm(self):
+        small = torch.nn.Parameter(torch.full((4,), 0.5))
+        large = torch.nn.Parameter(torch.full((4,), 5.0))
+        for param in (small, large):
+            param.grad = torch.full((4,), 100.0)
+        adaptive_grad_clip_([small], clip=0.3)
+        adaptive_grad_clip_([large], clip=0.3)
+        assert float(large.grad.norm()) == pytest.approx(
+            10.0 * float(small.grad.norm()), rel=1e-4
+        )
+
+    def test_zero_weights_still_receive_gradient_via_epsilon(self):
+        # Zero-initialized output layers must not have their gradients zeroed.
+        param = torch.nn.Parameter(torch.zeros(4))
+        param.grad = torch.full((4,), 1.0)
+        adaptive_grad_clip_([param], clip=0.3, eps=1e-3)
+        assert float(param.grad.abs().sum()) > 0.0
+
+    def test_returns_the_pre_clipping_norm(self):
+        param = torch.nn.Parameter(torch.ones(4))
+        param.grad = torch.full((4,), 3.0)
+        total = adaptive_grad_clip_([param], clip=0.3)
+        assert float(total) == pytest.approx(6.0, rel=1e-5)
+
+    def test_handles_parameters_without_gradients(self):
+        param = torch.nn.Parameter(torch.ones(4))
+        assert float(adaptive_grad_clip_([param])) == 0.0
+
+    def test_rejects_non_positive_clip(self):
+        with pytest.raises(ValueError, match="clip"):
+            adaptive_grad_clip_([], clip=0.0)
+
+
+class TestLaProp:
+    def test_minimizes_a_quadratic(self):
+        param = torch.nn.Parameter(torch.tensor([5.0]))
+        optimizer = LaProp([param], lr=0.1)
+        for _ in range(300):
+            optimizer.zero_grad()
+            (param**2).sum().backward()
+            optimizer.step()
+        assert abs(float(param)) < 0.5
+
+    def test_first_step_size_is_bounded_by_the_learning_rate(self):
+        # RMSProp normalization makes the first update approximately +-lr,
+        # independent of the gradient magnitude.
+        for gradient in (1e-3, 1.0, 1e6):
+            param = torch.nn.Parameter(torch.zeros(1))
+            optimizer = LaProp([param], lr=0.01)
+            param.grad = torch.tensor([gradient])
+            optimizer.step()
+            assert float(param.abs()) == pytest.approx(0.01, rel=1e-3)
+
+    def test_tolerates_a_tiny_epsilon(self):
+        param = torch.nn.Parameter(torch.ones(3))
+        optimizer = LaProp([param], lr=1e-3, eps=1e-20)
+        param.grad = torch.full((3,), 1e-8)
+        optimizer.step()
+        assert torch.isfinite(param).all()
+
+    def test_zero_gradient_leaves_parameters_unchanged(self):
+        param = torch.nn.Parameter(torch.ones(3))
+        optimizer = LaProp([param], lr=0.1)
+        param.grad = torch.zeros(3)
+        optimizer.step()
+        assert torch.equal(param.detach(), torch.ones(3))
+
+    def test_state_roundtrip(self):
+        param = torch.nn.Parameter(torch.ones(3))
+        optimizer = LaProp([param], lr=0.1)
+        param.grad = torch.full((3,), 0.5)
+        optimizer.step()
+        state = optimizer.state_dict()
+
+        restored_param = torch.nn.Parameter(torch.ones(3))
+        restored = LaProp([restored_param], lr=0.1)
+        restored.load_state_dict(state)
+        assert restored.state[restored_param]["step"] == 1
+
+    def test_decoupled_weight_decay_shrinks_parameters(self):
+        param = torch.nn.Parameter(torch.ones(3))
+        optimizer = LaProp([param], lr=0.1, weight_decay=0.5)
+        param.grad = torch.zeros(3)
+        optimizer.step()
+        assert float(param[0]) < 1.0
+
+    def test_rejects_invalid_hyperparameters(self):
+        param = torch.nn.Parameter(torch.ones(1))
+        with pytest.raises(ValueError, match="learning rate"):
+            LaProp([param], lr=-1.0)
+        with pytest.raises(ValueError, match="beta1"):
+            LaProp([param], betas=(1.5, 0.99))
+        with pytest.raises(ValueError, match="beta2"):
+            LaProp([param], betas=(0.9, 1.5))
+        with pytest.raises(ValueError, match="epsilon"):
+            LaProp([param], eps=-1.0)
+
+    def test_rejects_sparse_gradients(self):
+        param = torch.nn.Parameter(torch.ones(3))
+        optimizer = LaProp([param], lr=0.1)
+        indices = torch.tensor([[0]])
+        values = torch.tensor([1.0])
+        param.grad = torch.sparse_coo_tensor(indices, values, (3,))
+        with pytest.raises(RuntimeError, match="sparse"):
+            optimizer.step()
+
+    def test_supports_a_closure(self):
+        param = torch.nn.Parameter(torch.tensor([2.0]))
+        optimizer = LaProp([param], lr=0.01)
+
+        def closure():
+            optimizer.zero_grad()
+            loss = (param**2).sum()
+            loss.backward()
+            return loss
+
+        assert float(optimizer.step(closure)) == pytest.approx(4.0)

--- a/tests/utils/test_dreamer_v3_utils.py
+++ b/tests/utils/test_dreamer_v3_utils.py
@@ -1,0 +1,271 @@
+"""Tests for the DreamerV3 robustness primitives."""
+
+import numpy as np
+import pytest
+import torch
+
+from world_models.utils.dreamer_utils import symexp, symlog
+from world_models.utils.dreamer_v3_utils import (
+    ReturnNormalizer,
+    SymexpTwoHotDist,
+    free_bits,
+    lambda_return,
+    twohot,
+)
+
+
+class TestSymlog:
+    def test_roundtrip(self):
+        values = torch.tensor([-1e6, -12.5, -1.0, 0.0, 1.0, 12.5, 1e6])
+        assert torch.allclose(symexp(symlog(values)), values, rtol=1e-4)
+
+    def test_approximates_identity_near_origin(self):
+        small = torch.tensor([-0.01, 0.0, 0.01])
+        assert torch.allclose(symlog(small), small, atol=1e-4)
+
+    def test_is_sign_preserving(self):
+        values = torch.tensor([-5.0, 5.0])
+        assert torch.sign(symlog(values)).tolist() == [-1.0, 1.0]
+
+
+class TestTwoHot:
+    @pytest.fixture
+    def bins(self):
+        return torch.linspace(-2.0, 2.0, 5)
+
+    def test_sums_to_one(self, bins):
+        encoded = twohot(torch.tensor([-1.7, 0.0, 0.3, 1.9]), bins)
+        assert torch.allclose(encoded.sum(-1), torch.ones(4))
+
+    def test_exactly_on_a_bin_is_one_hot(self, bins):
+        encoded = twohot(torch.tensor([1.0]), bins)
+        assert encoded[0].tolist() == [0.0, 0.0, 0.0, 1.0, 0.0]
+
+    def test_interpolates_between_neighbors(self, bins):
+        # 0.25 of the way from bin 0.0 (index 2) to bin 1.0 (index 3).
+        encoded = twohot(torch.tensor([0.25]), bins)
+        assert encoded[0, 2] == pytest.approx(0.75)
+        assert encoded[0, 3] == pytest.approx(0.25)
+
+    def test_expected_value_recovers_the_target(self, bins):
+        targets = torch.tensor([-1.3, 0.7, 1.55])
+        recovered = (twohot(targets, bins) * bins).sum(-1)
+        assert torch.allclose(recovered, targets, atol=1e-5)
+
+    def test_out_of_range_clips_to_boundary(self, bins):
+        encoded = twohot(torch.tensor([100.0, -100.0]), bins)
+        assert encoded[0, -1] == pytest.approx(1.0)
+        assert encoded[1, 0] == pytest.approx(1.0)
+
+    def test_preserves_shape(self, bins):
+        encoded = twohot(torch.zeros(3, 4), bins)
+        assert encoded.shape == (3, 4, 5)
+
+
+class TestSymexpTwoHotDist:
+    def test_zero_logits_predict_zero(self):
+        # Uniform logits over a symmetric grid must average to exactly zero,
+        # which is what makes zero-initializing the head heads useful.
+        dist = SymexpTwoHotDist(torch.zeros(4, 255), num_bins=255)
+        assert torch.allclose(dist.mean, torch.zeros(4), atol=1e-4)
+
+    def test_bins_span_many_orders_of_magnitude(self):
+        dist = SymexpTwoHotDist(torch.zeros(1, 255), num_bins=255, symlog_range=20.0)
+        assert dist.bins[0] < -1e8
+        assert dist.bins[-1] > 1e8
+        # Dense near the origin despite the huge span.
+        assert dist.bins.abs().min() < 0.1
+
+    def test_bins_are_finite_in_float32(self):
+        dist = SymexpTwoHotDist(torch.zeros(1, 255), num_bins=255, symlog_range=20.0)
+        assert torch.isfinite(dist.bins).all()
+
+    def test_log_prob_is_maximized_at_the_target(self):
+        target = torch.tensor([3.0])
+        logits = torch.zeros(1, 255, requires_grad=True)
+        optimizer = torch.optim.Adam([logits], lr=0.5)
+        for _ in range(200):
+            optimizer.zero_grad()
+            loss = -SymexpTwoHotDist(logits).log_prob(target).mean()
+            loss.backward()
+            optimizer.step()
+        assert SymexpTwoHotDist(logits).mean.item() == pytest.approx(3.0, abs=0.1)
+
+    def test_gradient_scale_is_independent_of_target_scale(self):
+        # The central claim of the two-hot loss: because the loss depends only
+        # on the predicted probabilities, a target of 1e6 produces the same
+        # gradient magnitude as a target of 1.
+        def twohot_grad_norm(target_value):
+            logits = torch.zeros(1, 255, requires_grad=True)
+            loss = (
+                -SymexpTwoHotDist(logits).log_prob(torch.tensor([target_value])).mean()
+            )
+            loss.backward()
+            assert logits.grad is not None
+            return float(logits.grad.abs().sum())
+
+        assert twohot_grad_norm(1e6) == pytest.approx(twohot_grad_norm(1.0), rel=1e-4)
+
+    def test_squared_error_gradient_does_scale_with_the_target(self):
+        # Contrast with the two-hot loss above: this is the failure mode that
+        # motivates it, and why a plain squared loss can diverge on large
+        # targets while an absolute loss stagnates on small ones.
+        def mse_grad_norm(target_value):
+            prediction = torch.zeros(1, requires_grad=True)
+            loss = 0.5 * (prediction - torch.tensor([target_value])).pow(2).mean()
+            loss.backward()
+            assert prediction.grad is not None
+            return float(prediction.grad.abs().sum())
+
+        assert mse_grad_norm(1e6) == pytest.approx(1e6 * mse_grad_norm(1.0), rel=1e-3)
+
+    def test_rejects_mismatched_logits(self):
+        with pytest.raises(ValueError, match="num_bins"):
+            SymexpTwoHotDist(torch.zeros(2, 7), num_bins=255)
+
+    def test_cross_entropy_to_self_equals_entropy(self):
+        logits = torch.randn(3, 255)
+        dist = SymexpTwoHotDist(logits)
+        probs = dist.probs
+        expected = -(probs * torch.log_softmax(logits, -1)).sum(-1)
+        assert torch.allclose(dist.cross_entropy_to(dist), expected, atol=1e-5)
+
+
+class TestReturnNormalizer:
+    def test_large_returns_are_scaled_down(self):
+        normalizer = ReturnNormalizer(decay=0.0)
+        returns = torch.linspace(0.0, 1000.0, 512)
+        scaled = normalizer(returns)
+        assert scaled.max() < returns.max()
+        assert normalizer.scale > 1.0
+
+    def test_small_returns_pass_through_unchanged(self):
+        # Under sparse rewards the percentile range collapses; the limit keeps
+        # the denominator at 1 so tiny returns are not amplified.
+        normalizer = ReturnNormalizer(decay=0.0, limit=1.0)
+        returns = torch.zeros(256)
+        returns[0] = 0.01
+        scaled = normalizer(returns)
+        assert torch.allclose(scaled, returns)
+
+    def test_denominator_never_drops_below_the_limit(self):
+        normalizer = ReturnNormalizer(decay=0.0, limit=1.0)
+        normalizer.update(torch.zeros(64))
+        assert float(normalizer.denominator()) == pytest.approx(1.0)
+
+    def test_is_robust_to_outliers(self):
+        # A single enormous return must not dominate the 5-95 percentile range.
+        normalizer = ReturnNormalizer(decay=0.0)
+        base = torch.ones(1000)
+        normalizer.update(base)
+        clean = normalizer.scale
+
+        outlier = base.clone()
+        outlier[0] = 1e9
+        normalizer_b = ReturnNormalizer(decay=0.0)
+        normalizer_b.update(outlier)
+        assert normalizer_b.scale == pytest.approx(clean, abs=1e-3)
+
+    def test_ema_smooths_across_batches(self):
+        normalizer = ReturnNormalizer(decay=0.9)
+        normalizer.update(torch.linspace(0, 100, 256))
+        first = normalizer.scale
+        normalizer.update(torch.zeros(256))
+        assert 0.0 < normalizer.scale < first
+
+    def test_state_roundtrip(self):
+        normalizer = ReturnNormalizer(decay=0.5, limit=2.0)
+        normalizer.update(torch.linspace(0, 10, 128))
+        restored = ReturnNormalizer()
+        restored.load_state_dict(normalizer.state_dict())
+        assert restored.scale == pytest.approx(normalizer.scale)
+        assert restored.limit == pytest.approx(2.0)
+
+    def test_rejects_invalid_percentiles(self):
+        with pytest.raises(ValueError):
+            ReturnNormalizer(low=95.0, high=5.0)
+
+
+class TestFreeBits:
+    def test_clips_below_the_threshold(self):
+        assert float(free_bits(torch.tensor(0.2), nats=1.0)) == pytest.approx(1.0)
+
+    def test_passes_through_above_the_threshold(self):
+        assert float(free_bits(torch.tensor(3.0), nats=1.0)) == pytest.approx(3.0)
+
+    def test_gradient_vanishes_once_minimized(self):
+        kl = torch.tensor(0.3, requires_grad=True)
+        free_bits(kl, nats=1.0).backward()
+        assert float(kl.grad) == 0.0
+
+    def test_gradient_flows_when_above_the_threshold(self):
+        kl = torch.tensor(2.0, requires_grad=True)
+        free_bits(kl, nats=1.0).backward()
+        assert float(kl.grad) == 1.0
+
+
+class TestLambdaReturn:
+    def test_lambda_one_is_the_monte_carlo_return(self):
+        rewards = torch.ones(4, 1)
+        values = torch.zeros(4, 1)
+        continues = torch.full((4, 1), 0.9)
+        returns = lambda_return(rewards, values, continues, torch.zeros(1), lambda_=1.0)
+        expected = 1 + 0.9 * (1 + 0.9 * (1 + 0.9 * 1))
+        assert float(returns[0]) == pytest.approx(expected)
+
+    def test_lambda_zero_is_the_one_step_target(self):
+        rewards = torch.ones(3, 1)
+        values = torch.full((3, 1), 5.0)
+        continues = torch.full((3, 1), 0.9)
+        returns = lambda_return(rewards, values, continues, torch.zeros(1), lambda_=0.0)
+        assert float(returns[0]) == pytest.approx(1.0 + 0.9 * 5.0)
+
+    def test_zero_continue_truncates_the_return(self):
+        rewards = torch.ones(3, 1)
+        values = torch.full((3, 1), 100.0)
+        continues = torch.zeros(3, 1)
+        returns = lambda_return(
+            rewards, values, continues, torch.full((1,), 100.0), lambda_=0.95
+        )
+        assert torch.allclose(returns, torch.ones(3, 1))
+
+    def test_shape_is_preserved(self):
+        returns = lambda_return(
+            torch.zeros(6, 4), torch.zeros(6, 4), torch.zeros(6, 4), torch.zeros(4)
+        )
+        assert returns.shape == (6, 4)
+
+    def test_rejects_mismatched_shapes(self):
+        with pytest.raises(ValueError, match="share a shape"):
+            lambda_return(
+                torch.zeros(3, 2),
+                torch.zeros(4, 2),
+                torch.zeros(3, 2),
+                torch.zeros(2),
+            )
+
+    def test_matches_an_explicit_recursion(self):
+        torch.manual_seed(0)
+        rewards = torch.randn(5, 2)
+        values = torch.randn(5, 2)
+        continues = torch.rand(5, 2)
+        bootstrap = torch.randn(2)
+        lam = 0.7
+
+        expected = torch.zeros(5, 2)
+        accumulated = bootstrap
+        for t in reversed(range(5)):
+            accumulated = rewards[t] + continues[t] * (
+                (1 - lam) * values[t] + lam * accumulated
+            )
+            expected[t] = accumulated
+
+        actual = lambda_return(rewards, values, continues, bootstrap, lambda_=lam)
+        assert torch.allclose(actual, expected, atol=1e-5)
+
+
+class TestNumpyInterop:
+    def test_twohot_matches_manual_numpy_computation(self):
+        bins = torch.tensor([0.0, 1.0, 2.0])
+        encoded = twohot(torch.tensor([0.4]), bins).numpy()
+        assert np.allclose(encoded, [[0.6, 0.4, 0.0]], atol=1e-6)

--- a/world_models/__init__.py
+++ b/world_models/__init__.py
@@ -53,6 +53,7 @@ _LAZY_EXPORTS: dict[str, str] = {
     "DreamerV1": "world_models.models",
     "DreamerV2": "world_models.models",
     "DreamerV3": "world_models.models",
+    "DreamerV3Agent": "world_models.models",
     "DreamerAgent": "world_models.models",
     "Planet": "world_models.models",
     "JEPAAgent": "world_models.models",
@@ -73,7 +74,12 @@ _LAZY_EXPORTS: dict[str, str] = {
     "RSSM": "world_models.models",
     "RecurrentStateSpaceModel": "world_models.models",
     "DreamerRSSM": "world_models.models.dreamer_rssm",
+    "CategoricalRSSM": "world_models.models",
     # Vision components.
+    "DreamerV3Encoder": "world_models.vision",
+    "DreamerV3Decoder": "world_models.vision",
+    "DreamerV3Head": "world_models.vision",
+    "DreamerV3Actor": "world_models.vision",
     "ConvEncoder": "world_models.vision",
     "CNNEncoder": "world_models.vision",
     "ConvDecoder": "world_models.vision",
@@ -90,6 +96,7 @@ _LAZY_EXPORTS: dict[str, str] = {
     "VectorQuantizerEMA": "world_models.vision",
     # Memory.
     "ReplayBuffer": "world_models.memory",
+    "DreamerV3ReplayBuffer": "world_models.memory",
     "Memory": "world_models.memory",
     "Episode": "world_models.memory",
     "IRISReplayBuffer": "world_models.memory",
@@ -118,6 +125,7 @@ _LAZY_EXPORTS: dict[str, str] = {
     "CNNFeatureExtractor": "world_models.controller",
     # Configs.
     "DreamerConfig": "world_models.configs",
+    "DreamerV3Config": "world_models.configs",
     "JEPAConfig": "world_models.configs",
     "DiTConfig": "world_models.configs",
     "get_dit_config": "world_models.configs",

--- a/world_models/api.py
+++ b/world_models/api.py
@@ -56,9 +56,13 @@ MODEL_SPECS: dict[str, ModelSpec] = {
     ),
     "dreamer-v3": ModelSpec(
         name="dreamer-v3",
-        import_path="world_models.models.dreamer:DreamerAgent",
-        config_path="world_models.configs.dreamer_config:DreamerConfig",
-        description="DreamerV3-style agent (currently mapped to DreamerAgent; update when dedicated V3 implementation lands).",
+        import_path="world_models.models.dreamer_v3:DreamerV3Agent",
+        config_path="world_models.configs.dreamer_v3_config:DreamerV3Config",
+        description=(
+            "DreamerV3 agent: categorical latents with free bits, symexp two-hot "
+            "reward and critic heads, percentile return normalization, and "
+            "LaProp with adaptive gradient clipping."
+        ),
         aliases=("dreamerv3",),
     ),
     "planet": ModelSpec(

--- a/world_models/catalog.py
+++ b/world_models/catalog.py
@@ -259,6 +259,9 @@ def _build_env_catalog() -> dict[str, list[str]]:
         "dreamer": dreamer_envs,
         "dreamerv1": dreamer_envs,
         "dreamerv2": dreamer_envs,
+        # DreamerV3 additionally handles discrete action spaces through the
+        # one-hot action wrapper, so Atari is in scope for it.
+        "dreamerv3": _dedupe_envs(dreamer_envs, atari_envs[:80]),
         "planet": planet_envs,
         "rssm": planet_envs,
         "iris": atari_and_robotics_envs,

--- a/world_models/configs/__init__.py
+++ b/world_models/configs/__init__.py
@@ -11,6 +11,8 @@ from typing import Any
 
 _EXPORTS = {
     "DreamerConfig": "world_models.configs.dreamer_config",
+    "DreamerV3Config": "world_models.configs.dreamer_v3_config",
+    "MODEL_SIZES": "world_models.configs.dreamer_v3_config",
     "JEPAConfig": "world_models.configs.jepa_config",
     "DiTConfig": "world_models.configs.dit_config",
     "get_dit_config": "world_models.configs.dit_config",

--- a/world_models/configs/dreamer_v3_config.py
+++ b/world_models/configs/dreamer_v3_config.py
@@ -1,0 +1,221 @@
+"""Configuration for DreamerV3.
+
+:class:`DreamerV3Config` extends :class:`~world_models.configs.dreamer_config.DreamerConfig`
+so every environment backend option carries over unchanged, then overrides the
+optimization defaults and adds the fields introduced by DreamerV3. The defaults
+reproduce Table 4 of the paper and are intended to be used unmodified across
+domains -- that fixed-hyperparameter property is the central claim of the work.
+
+Reference:
+    Mastering Diverse Domains through World Models
+    Hafner et al., 2023 - https://arxiv.org/abs/2301.04104
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from world_models.configs.dreamer_config import DreamerConfig
+
+__all__ = ["DreamerV3Config", "MODEL_SIZES"]
+
+
+# Table 3: the model dimension `d` determines every other width. Recurrent units
+# are `8d` (split into 8 blocks of size `d`), while convolution channels and
+# latent classes are `d / 16`. Layer and latent counts stay fixed across sizes.
+MODEL_SIZES: dict[str, dict[str, int]] = {
+    "12m": {
+        "hidden_size": 256,
+        "recurrent_units": 1024,
+        "cnn_depth": 16,
+        "latent_classes": 16,
+    },
+    "25m": {
+        "hidden_size": 384,
+        "recurrent_units": 3072,
+        "cnn_depth": 24,
+        "latent_classes": 24,
+    },
+    "50m": {
+        "hidden_size": 512,
+        "recurrent_units": 4096,
+        "cnn_depth": 32,
+        "latent_classes": 32,
+    },
+    "100m": {
+        "hidden_size": 768,
+        "recurrent_units": 6144,
+        "cnn_depth": 48,
+        "latent_classes": 48,
+    },
+    "200m": {
+        "hidden_size": 1024,
+        "recurrent_units": 8192,
+        "cnn_depth": 64,
+        "latent_classes": 64,
+    },
+    "400m": {
+        "hidden_size": 1536,
+        "recurrent_units": 12288,
+        "cnn_depth": 96,
+        "latent_classes": 96,
+    },
+}
+
+
+@dataclass
+class DreamerV3Config(DreamerConfig):
+    """Hyperparameters for DreamerV3 training and evaluation.
+
+    Width fields left as ``None`` are filled in from ``model_size`` when the
+    config is constructed, so ``DreamerV3Config(model_size="200m")`` is all that
+    is needed to scale the agent up. Setting a width explicitly overrides the
+    preset for that field only.
+    """
+
+    algo: str = "DreamerV3"
+
+    # ------------------------------------------------------------------
+    # Architecture
+    # ------------------------------------------------------------------
+    # One of MODEL_SIZES. The paper reports monotonically better performance and
+    # lower data requirements as this grows, with all other values held fixed.
+    model_size: str = "12m"
+    hidden_size: int | None = None
+    recurrent_units: int | None = None
+    cnn_depth: int | None = None
+    latent_classes: int | None = None
+    latent_dim: int = 32
+    gru_blocks: int = 8
+    mlp_layers: int = 3
+    activation: str = "silu"
+    # Uniform mixture for world model latents and the discrete policy, which
+    # keeps categorical distributions from becoming deterministic.
+    unimix: float = 0.01
+    # "auto" resolves to "onehot" or "normal" from the environment action space.
+    actor_dist: str = "auto"
+    actor_min_std: float = 0.1
+    actor_max_std: float = 1.0
+
+    # ------------------------------------------------------------------
+    # World model losses
+    # ------------------------------------------------------------------
+    beta_pred: float = 1.0
+    beta_dyn: float = 1.0
+    beta_rep: float = 0.1
+    # Free bits: KL terms are clipped below this many nats so that, once they are
+    # minimized well, learning focuses on the prediction loss instead.
+    free_nats: float = 1.0
+
+    # ------------------------------------------------------------------
+    # Actor critic
+    # ------------------------------------------------------------------
+    discount: float = 0.997
+    td_lambda: float = 0.95
+    imagine_horizon: int = 15
+    actor_entropy: float = 3e-4
+    critic_loss_scale: float = 1.0
+    # Applying the critic loss to replayed trajectories as well improves value
+    # prediction where rewards are hard to predict from imagination alone.
+    critic_replay_loss_scale: float = 0.3
+    critic_ema_decay: float = 0.98
+    critic_ema_regularizer: float = 1.0
+    # Percentile return normalization. Returns are divided by an EMA of the
+    # 5th-to-95th percentile range, but only when that range exceeds the limit,
+    # so small returns under sparse rewards are not amplified.
+    return_norm_decay: float = 0.99
+    return_norm_limit: float = 1.0
+    return_norm_low: float = 5.0
+    return_norm_high: float = 95.0
+
+    # ------------------------------------------------------------------
+    # Prediction heads
+    # ------------------------------------------------------------------
+    num_buckets: int = 255
+    # Bin locations are symexp(linspace(-symlog_range, +symlog_range, buckets)).
+    symlog_range: float = 20.0
+
+    # ------------------------------------------------------------------
+    # Optimization
+    # ------------------------------------------------------------------
+    # DreamerV3 uses one learning rate for all three optimizers.
+    learning_rate: float = 4e-5
+    agc_clip: float = 0.3
+    agc_eps: float = 1e-3
+    opt_eps: float = 1e-20
+    opt_beta1: float = 0.9
+    opt_beta2: float = 0.99
+    weight_decay: float = 0.0
+
+    batch_size: int = 16
+    train_seq_len: int = 64
+    # Time steps trained on per environment step collected, before action
+    # repeat. `update_steps` is derived from this unless auto_update_steps=False.
+    replay_ratio: int = 32
+    auto_update_steps: bool = True
+    online_fraction: float = 0.5
+    buffer_size: int = 1_000_000
+
+    use_amp: bool = False
+    grad_clip_norm: float = 0.0  # Superseded by adaptive gradient clipping.
+    seed_steps: int = 5000
+    collect_steps: int = 1000
+    action_repeat: int = 2
+    action_noise: float = 0.0  # Exploration comes from the entropy regularizer.
+
+    def __post_init__(self) -> None:
+        parent_post_init = getattr(super(), "__post_init__", None)
+        if callable(parent_post_init):
+            parent_post_init()
+        self.resolve()
+
+    def resolve(self) -> "DreamerV3Config":
+        """Fill in width fields from ``model_size`` and derive ``update_steps``."""
+        key = str(self.model_size).strip().lower()
+        if key not in MODEL_SIZES:
+            options = ", ".join(sorted(MODEL_SIZES, key=lambda name: int(name[:-1])))
+            raise ValueError(
+                f"Unknown model_size {self.model_size!r}. Options: {options}"
+            )
+
+        preset = MODEL_SIZES[key]
+        for field_name, value in preset.items():
+            if getattr(self, field_name) is None:
+                setattr(self, field_name, value)
+
+        if self.recurrent_units is not None and self.recurrent_units % self.gru_blocks:
+            raise ValueError(
+                f"recurrent_units={self.recurrent_units} must be divisible by "
+                f"gru_blocks={self.gru_blocks}."
+            )
+
+        if self.auto_update_steps:
+            steps_per_batch = max(1, self.batch_size * self.train_seq_len)
+            self.update_steps = max(
+                1, round(self.collect_steps * self.replay_ratio / steps_per_batch)
+            )
+        return self
+
+    # ------------------------------------------------------------------
+    # Convenience accessors, so downstream code never sees `None`.
+    # ------------------------------------------------------------------
+
+    @property
+    def resolved_hidden_size(self) -> int:
+        return int(self.hidden_size or MODEL_SIZES[self.model_size]["hidden_size"])
+
+    @property
+    def resolved_recurrent_units(self) -> int:
+        return int(
+            self.recurrent_units or MODEL_SIZES[self.model_size]["recurrent_units"]
+        )
+
+    @property
+    def resolved_cnn_depth(self) -> int:
+        return int(self.cnn_depth or MODEL_SIZES[self.model_size]["cnn_depth"])
+
+    @property
+    def resolved_latent_classes(self) -> int:
+        return int(
+            self.latent_classes or MODEL_SIZES[self.model_size]["latent_classes"]
+        )

--- a/world_models/layers/__init__.py
+++ b/world_models/layers/__init__.py
@@ -1,6 +1,7 @@
 """Normalization and neural network layers used by TorchWM."""
 
 from .ada_ln_norm import AdaLNNormalization
+from .block_gru import BlockGRUCell, BlockLinear
 from .rms_norm import RMSNorm
 
-__all__ = ["AdaLNNormalization", "RMSNorm"]
+__all__ = ["AdaLNNormalization", "BlockGRUCell", "BlockLinear", "RMSNorm"]

--- a/world_models/layers/block_gru.py
+++ b/world_models/layers/block_gru.py
@@ -1,0 +1,165 @@
+"""Block-diagonal GRU used by the DreamerV3 sequence model.
+
+A standard GRU's recurrent weights grow quadratically with the number of hidden
+units, which makes wide recurrent states expensive. DreamerV3 instead splits the
+recurrent state into ``blocks`` equally sized groups and applies a separate
+recurrent weight matrix within each group. Parameters and FLOPs then grow
+linearly in the number of units for a fixed block size.
+
+Mixing between blocks is not lost: the GRU input at each step is a dense linear
+embedding of the sampled latent, the action, *and* the previous recurrent state,
+so information can still cross block boundaries once per timestep.
+
+Reference:
+    Van Keirsbilck et al., 2019 - https://arxiv.org/abs/1905.12340
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn as nn
+
+from world_models.layers.rms_norm import RMSNorm
+
+__all__ = ["BlockLinear", "BlockGRUCell"]
+
+
+class BlockLinear(nn.Module):
+    """Linear layer applied independently within each of ``blocks`` groups.
+
+    Equivalent to a dense layer whose weight matrix is constrained to be
+    block-diagonal, but stored and applied as a batched matmul.
+
+    Args:
+        in_features: Total input size; must be divisible by ``blocks``.
+        out_features: Total output size; must be divisible by ``blocks``.
+        blocks: Number of independent groups.
+        bias: Whether to learn an additive bias.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        blocks: int,
+        bias: bool = True,
+    ) -> None:
+        super().__init__()
+        if in_features % blocks != 0:
+            raise ValueError(
+                f"in_features={in_features} is not divisible by blocks={blocks}"
+            )
+        if out_features % blocks != 0:
+            raise ValueError(
+                f"out_features={out_features} is not divisible by blocks={blocks}"
+            )
+
+        self.in_features = int(in_features)
+        self.out_features = int(out_features)
+        self.blocks = int(blocks)
+        self.in_per_block = self.in_features // self.blocks
+        self.out_per_block = self.out_features // self.blocks
+
+        self.weight = nn.Parameter(
+            torch.empty(self.blocks, self.in_per_block, self.out_per_block)
+        )
+        self.bias = nn.Parameter(torch.zeros(self.out_features)) if bias else None
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        bound = 1.0 / math.sqrt(self.in_per_block)
+        nn.init.uniform_(self.weight, -bound, bound)
+        if self.bias is not None:
+            nn.init.zeros_(self.bias)
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        """Apply the block-diagonal transform.
+
+        Args:
+            inputs: Tensor of shape ``(*batch, in_features)``.
+
+        Returns:
+            Tensor of shape ``(*batch, out_features)``.
+        """
+        batch_shape = inputs.shape[:-1]
+        blocked = inputs.reshape(*batch_shape, self.blocks, self.in_per_block)
+        out = torch.einsum("...bi,bio->...bo", blocked, self.weight)
+        out = out.reshape(*batch_shape, self.out_features)
+        if self.bias is not None:
+            out = out + self.bias
+        return out
+
+    def extra_repr(self) -> str:
+        return (
+            f"in_features={self.in_features}, out_features={self.out_features}, "
+            f"blocks={self.blocks}, bias={self.bias is not None}"
+        )
+
+
+class BlockGRUCell(nn.Module):
+    """GRU cell with block-diagonal recurrent weights and RMSNorm gating.
+
+    The cell expects the caller to supply a dense input embedding of size
+    ``hidden_size`` (the DreamerV3 RSSM builds it from the latent, the action,
+    and the previous recurrent state, which is what allows blocks to mix).
+
+    Args:
+        hidden_size: Size of the recurrent state; must be divisible by ``blocks``.
+        blocks: Number of independent recurrent groups.
+        norm: Whether to normalize the gate pre-activations with RMSNorm.
+    """
+
+    def __init__(self, hidden_size: int, blocks: int = 8, norm: bool = True) -> None:
+        super().__init__()
+        if hidden_size % blocks != 0:
+            raise ValueError(
+                f"hidden_size={hidden_size} is not divisible by blocks={blocks}"
+            )
+        self.hidden_size = int(hidden_size)
+        self.blocks = int(blocks)
+        self.per_block = self.hidden_size // self.blocks
+
+        # Each block sees its own slice of the input embedding and of the state.
+        self.block_linear = BlockLinear(
+            2 * self.hidden_size, 3 * self.hidden_size, self.blocks, bias=not norm
+        )
+        self.norm = RMSNorm(3 * self.per_block) if norm else None
+
+    def forward(self, inputs: torch.Tensor, state: torch.Tensor) -> torch.Tensor:
+        """Advance the recurrent state by one step.
+
+        Args:
+            inputs: Input embedding of shape ``(*batch, hidden_size)``.
+            state: Previous recurrent state of shape ``(*batch, hidden_size)``.
+
+        Returns:
+            Updated recurrent state of shape ``(*batch, hidden_size)``.
+        """
+        batch_shape = inputs.shape[:-1]
+        # Interleave input and state per block so block b sees only slice b of
+        # each. A plain concatenation would hand block 0 only input features.
+        blocked_inputs = inputs.reshape(*batch_shape, self.blocks, self.per_block)
+        blocked_state = state.reshape(*batch_shape, self.blocks, self.per_block)
+        combined = torch.cat([blocked_inputs, blocked_state], dim=-1)
+        combined = combined.reshape(*batch_shape, 2 * self.hidden_size)
+
+        parts = self.block_linear(combined)
+        parts = parts.reshape(*batch_shape, self.blocks, 3 * self.per_block)
+        if self.norm is not None:
+            parts = self.norm(parts)
+
+        reset, cand, update = torch.chunk(parts, 3, dim=-1)
+        reset = torch.sigmoid(reset)
+        cand = torch.tanh(reset * cand)
+        # The -1 offset biases the gate towards keeping the previous state,
+        # which stabilizes long-horizon credit assignment early in training.
+        update = torch.sigmoid(update - 1.0)
+
+        cand = cand.reshape(*batch_shape, self.hidden_size)
+        update = update.reshape(*batch_shape, self.hidden_size)
+        return update * cand + (1.0 - update) * state
+
+    def extra_repr(self) -> str:
+        return f"hidden_size={self.hidden_size}, blocks={self.blocks}"

--- a/world_models/memory/__init__.py
+++ b/world_models/memory/__init__.py
@@ -13,6 +13,7 @@ from typing import Any
 
 __all__ = [
     "ReplayBuffer",
+    "DreamerV3ReplayBuffer",
     "Episode",
     "Memory",
     "IRISReplayBuffer",
@@ -25,6 +26,10 @@ def __getattr__(name: str) -> Any:
         from .dreamer_memory import ReplayBuffer
 
         return ReplayBuffer
+    if name == "DreamerV3ReplayBuffer":
+        from .dreamer_v3_memory import DreamerV3ReplayBuffer
+
+        return DreamerV3ReplayBuffer
     if name == "Episode":
         from .planet_memory import Episode
 

--- a/world_models/memory/dreamer_v3_memory.py
+++ b/world_models/memory/dreamer_v3_memory.py
@@ -1,0 +1,215 @@
+"""Replay buffer for DreamerV3.
+
+Three differences from :class:`~world_models.memory.dreamer_memory.ReplayBuffer`
+matter for DreamerV3:
+
+* **Sequences may span episode boundaries.** Instead of rejecting such windows,
+  the buffer records an ``is_first`` flag at every episode start and the world
+  model resets its recurrent state where that flag is set. This removes the
+  rejection-sampling loop and keeps short episodes usable.
+* **An online queue.** Each minibatch is filled first from recently collected,
+  non-overlapping trajectories and only then topped up with uniform samples.
+  This keeps the world model current with the behavior policy.
+* **Terminal versus truncation.** ``is_terminal`` marks true environment
+  terminations, which is what the continue predictor is trained on; time-limit
+  truncations end a trajectory without implying zero future value.
+
+Reference:
+    Mastering Diverse Domains through World Models
+    Hafner et al., 2023 - https://arxiv.org/abs/2301.04104
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any, Deque, Sequence
+
+import numpy as np
+
+__all__ = ["DreamerV3ReplayBuffer"]
+
+
+class DreamerV3ReplayBuffer:
+    """Ring buffer over transitions, sampled as fixed-length sequences.
+
+    Args:
+        size: Maximum number of transitions retained.
+        obs_shape: Shape of a single observation.
+        action_size: Dimension of the action vector.
+        seq_len: Length of the sampled sequences.
+        batch_size: Number of sequences per batch.
+        obs_dtype: Storage dtype for observations. ``uint8`` for images keeps
+            the buffer four times smaller than ``float32``.
+        online_fraction: Fraction of each batch drawn from the online queue.
+    """
+
+    def __init__(
+        self,
+        size: int,
+        obs_shape: Sequence[int],
+        action_size: int,
+        seq_len: int,
+        batch_size: int,
+        obs_dtype: Any = np.uint8,
+        online_fraction: float = 0.5,
+    ) -> None:
+        if seq_len < 2:
+            raise ValueError(f"seq_len must be at least 2, got {seq_len}")
+        if not 0.0 <= online_fraction <= 1.0:
+            raise ValueError(
+                f"online_fraction must be in [0, 1], got {online_fraction}"
+            )
+
+        self.size = int(size)
+        self.obs_shape = tuple(int(dim) for dim in obs_shape)
+        self.action_size = int(action_size)
+        self.seq_len = int(seq_len)
+        self.batch_size = int(batch_size)
+        self.online_fraction = float(online_fraction)
+
+        self.observations = np.empty((self.size, *self.obs_shape), dtype=obs_dtype)
+        self.actions = np.empty((self.size, self.action_size), dtype=np.float32)
+        self.rewards = np.empty((self.size,), dtype=np.float32)
+        self.is_terminal = np.empty((self.size,), dtype=np.float32)
+        self.is_first = np.empty((self.size,), dtype=np.float32)
+
+        self.idx = 0
+        self.full = False
+        self.steps = 0
+        self.episodes = 0
+        self._next_is_first = True
+        self._online: Deque[int] = deque(maxlen=max(1, self.batch_size * 4))
+        self._since_online_start = 0
+
+    # ------------------------------------------------------------------
+    # Writing
+    # ------------------------------------------------------------------
+
+    def add(
+        self,
+        obs: dict | np.ndarray,
+        action: np.ndarray,
+        reward: float,
+        done: bool | float,
+        is_terminal: bool | float | None = None,
+    ) -> None:
+        """Append one transition.
+
+        Args:
+            obs: Observation, either a raw array or a dict with an ``"image"``
+                (or ``"obs"``) key.
+            action: Action taken from this observation.
+            reward: Reward received for that action.
+            done: Whether the episode ended here, for any reason.
+            is_terminal: Whether the episode ended by true termination rather
+                than by a time limit. Defaults to ``done``, which is the correct
+                choice only when the environment does not truncate.
+        """
+        array = self._extract_obs(obs)
+        self.observations[self.idx] = array
+        self.actions[self.idx] = np.asarray(action, dtype=np.float32).reshape(-1)
+        self.rewards[self.idx] = float(reward)
+        self.is_terminal[self.idx] = float(done if is_terminal is None else is_terminal)
+        self.is_first[self.idx] = float(self._next_is_first)
+
+        # Register a fresh online window every `seq_len` steps so the queued
+        # trajectories do not overlap.
+        if self._since_online_start % self.seq_len == 0:
+            self._online.append(self.idx)
+        self._since_online_start += 1
+
+        self._next_is_first = bool(done)
+        self.idx = (self.idx + 1) % self.size
+        self.full = self.full or self.idx == 0
+        self.steps += 1
+        if done:
+            self.episodes += 1
+
+    def _extract_obs(self, obs: dict | np.ndarray) -> np.ndarray:
+        if isinstance(obs, dict):
+            for key in ("image", "obs"):
+                if key in obs:
+                    return np.asarray(obs[key])
+            raise KeyError(
+                f"Observation dict has no 'image' or 'obs' key: {sorted(obs)}"
+            )
+        return np.asarray(obs)
+
+    # ------------------------------------------------------------------
+    # Sampling
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        return self.size if self.full else self.idx
+
+    @property
+    def can_sample(self) -> bool:
+        return len(self) > self.seq_len + 1
+
+    def _valid_range(self) -> int:
+        """Number of positions a sequence may start at without crossing the head."""
+        return len(self) - self.seq_len
+
+    def _sample_start(self) -> int:
+        upper = self._valid_range()
+        if upper <= 0:
+            return 0
+        if self.full:
+            # Start anywhere except a window that would run over the write head.
+            offset = int(np.random.randint(0, self.size - self.seq_len))
+            return (self.idx + offset) % self.size
+        return int(np.random.randint(0, upper))
+
+    def _pop_online_start(self) -> int | None:
+        while self._online:
+            start = self._online[0]
+            if self._window_is_complete(start):
+                self._online.popleft()
+                return start
+            return None
+        return None
+
+    def _window_is_complete(self, start: int) -> bool:
+        """Whether ``seq_len`` transitions after ``start`` have been written."""
+        written = (self.idx - start) % self.size
+        if not self.full and start >= self.idx:
+            return False
+        return written >= self.seq_len
+
+    def sample(
+        self,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Draw a batch of sequences.
+
+        Returns:
+            Tuple ``(observations, actions, rewards, is_terminal, is_first)``
+            with leading dimensions ``(seq_len, batch_size)``.
+        """
+        if not self.can_sample:
+            raise RuntimeError(
+                f"Replay buffer holds {len(self)} transitions, which is not "
+                f"enough for sequences of length {self.seq_len}."
+            )
+
+        starts: list[int] = []
+        target_online = int(round(self.batch_size * self.online_fraction))
+        while len(starts) < target_online:
+            start = self._pop_online_start()
+            if start is None:
+                break
+            starts.append(start)
+        while len(starts) < self.batch_size:
+            starts.append(self._sample_start())
+
+        index = (
+            np.asarray(starts, dtype=np.int64)[None, :]
+            + np.arange(self.seq_len, dtype=np.int64)[:, None]
+        ) % self.size
+
+        return (
+            self.observations[index],
+            self.actions[index],
+            self.rewards[index],
+            self.is_terminal[index],
+            self.is_first[index],
+        )

--- a/world_models/models/__init__.py
+++ b/world_models/models/__init__.py
@@ -29,7 +29,9 @@ __all__ = [
     "DreamerV1",
     "DreamerV2",
     "DreamerV3",
+    "DreamerV3Agent",
     "DreamerAgent",
+    "CategoricalRSSM",
     "Planet",
     "JEPAAgent",
     "IRISAgent",
@@ -71,9 +73,17 @@ def __getattr__(name: str) -> Any:
 
         return DreamerV2
     if name == "DreamerV3":
-        from .dreamer import DreamerAgent
+        from .dreamer_v3 import DreamerV3
 
-        return DreamerAgent
+        return DreamerV3
+    if name == "DreamerV3Agent":
+        from .dreamer_v3 import DreamerV3Agent
+
+        return DreamerV3Agent
+    if name == "CategoricalRSSM":
+        from .categorical_rssm import CategoricalRSSM
+
+        return CategoricalRSSM
     if name == "DreamerAgent":
         from .dreamer import DreamerAgent
 

--- a/world_models/models/categorical_rssm.py
+++ b/world_models/models/categorical_rssm.py
@@ -1,0 +1,343 @@
+"""Recurrent State-Space Model with categorical latents (DreamerV3).
+
+Where DreamerV1/V2's :class:`~world_models.models.dreamer_rssm.RSSM` parametrizes
+the stochastic state as a diagonal Gaussian, DreamerV3 uses a vector of
+independent categorical variables sampled with straight-through gradients. The
+model state is ``s_t = {h_t, z_t}``:
+
+.. code-block:: text
+
+    Sequence model:      h_t = f(h_{t-1}, z_{t-1}, a_{t-1})
+    Encoder (posterior): z_t ~ q(z_t | h_t, x_t)
+    Dynamics (prior):    z_t ~ p(z_t | h_t)
+
+Two details matter for stability and are implemented here:
+
+* **Unimix.** Every categorical is a mixture of 99% network output and 1%
+  uniform. This makes it impossible for a distribution to become deterministic
+  and keeps the KL terms well behaved.
+* **Straight-through sampling.** The forward pass uses a hard one-hot sample
+  while the backward pass sees the soft probabilities, so gradients reach the
+  logits.
+
+Reference:
+    Mastering Diverse Domains through World Models
+    Hafner et al., 2023 - https://arxiv.org/abs/2301.04104
+"""
+
+from __future__ import annotations
+
+from typing import Any, Tuple
+
+import torch
+import torch.distributions as distributions
+import torch.nn as nn
+
+from world_models.layers.block_gru import BlockGRUCell
+from world_models.layers.rms_norm import RMSNorm
+
+__all__ = ["CategoricalRSSM"]
+
+_ACTIVATIONS: dict[str, type[nn.Module]] = {
+    "silu": nn.SiLU,
+    "swish": nn.SiLU,
+    "elu": nn.ELU,
+    "relu": nn.ReLU,
+    "gelu": nn.GELU,
+    "tanh": nn.Tanh,
+}
+
+
+def _activation(name: str) -> nn.Module:
+    try:
+        return _ACTIVATIONS[name.lower()]()
+    except KeyError as exc:
+        options = ", ".join(sorted(_ACTIVATIONS))
+        raise ValueError(f"Unknown activation {name!r}. Options: {options}") from exc
+
+
+class CategoricalRSSM(nn.Module):
+    """DreamerV3 world model dynamics over categorical latent states.
+
+    Args:
+        action_size: Dimension of the (one-hot or continuous) action vector.
+        embed_size: Size of the observation embedding produced by the encoder.
+        latent_dim: Number of categorical variables per latent state.
+        latent_classes: Number of classes per categorical variable.
+        deter_size: Size of the recurrent state ``h``.
+        hidden_size: Width of the MLPs inside the model.
+        gru_blocks: Number of block-diagonal groups in the sequence model.
+        unimix: Fraction of uniform probability mixed into every categorical.
+        activation: Activation used by the internal MLPs.
+    """
+
+    def __init__(
+        self,
+        action_size: int,
+        embed_size: int,
+        latent_dim: int = 32,
+        latent_classes: int = 32,
+        deter_size: int = 1024,
+        hidden_size: int = 256,
+        gru_blocks: int = 8,
+        unimix: float = 0.01,
+        activation: str = "silu",
+    ) -> None:
+        super().__init__()
+
+        self.action_size = int(action_size)
+        self.embed_size = int(embed_size)
+        self.latent_dim = int(latent_dim)
+        self.latent_classes = int(latent_classes)
+        self.deter_size = int(deter_size)
+        self.hidden_size = int(hidden_size)
+        self.unimix = float(unimix)
+        self.stoch_size = self.latent_dim * self.latent_classes
+        self.feature_size = self.stoch_size + self.deter_size
+
+        # Sequence model: embed (z, a, h) densely, then advance the block GRU.
+        self.gru_input = nn.Sequential(
+            nn.Linear(self.stoch_size + self.action_size + self.deter_size, deter_size),
+            RMSNorm(deter_size),
+            _activation(activation),
+        )
+        self.gru = BlockGRUCell(self.deter_size, blocks=gru_blocks)
+
+        # Dynamics predictor p(z_t | h_t).
+        self.prior_net = nn.Sequential(
+            nn.Linear(self.deter_size, self.hidden_size),
+            RMSNorm(self.hidden_size),
+            _activation(activation),
+            nn.Linear(self.hidden_size, self.stoch_size),
+        )
+        # Encoder posterior q(z_t | h_t, x_t).
+        self.posterior_net = nn.Sequential(
+            nn.Linear(self.deter_size + self.embed_size, self.hidden_size),
+            RMSNorm(self.hidden_size),
+            _activation(activation),
+            nn.Linear(self.hidden_size, self.stoch_size),
+        )
+
+    # ------------------------------------------------------------------
+    # State helpers
+    # ------------------------------------------------------------------
+
+    def init_state(self, batch_size: int, device: torch.device) -> dict:
+        """Return a zero-initialized model state."""
+        return dict(
+            logit=torch.zeros(
+                batch_size, self.latent_dim, self.latent_classes, device=device
+            ),
+            stoch=torch.zeros(
+                batch_size, self.latent_dim, self.latent_classes, device=device
+            ),
+            deter=torch.zeros(batch_size, self.deter_size, device=device),
+        )
+
+    def get_feat(self, state: dict) -> torch.Tensor:
+        """Concatenate the flattened stochastic and deterministic state."""
+        stoch = state["stoch"]
+        flat = stoch.reshape(*stoch.shape[:-2], self.stoch_size)
+        return torch.cat([flat, state["deter"]], dim=-1)
+
+    def detach_state(self, state: dict) -> dict:
+        return {key: value.detach() for key, value in state.items()}
+
+    def seq_to_batch(self, state: dict) -> dict:
+        """Flatten a ``(T, B, ...)`` state into ``(T * B, ...)``."""
+        return {
+            key: value.reshape(-1, *value.shape[2:]) for key, value in state.items()
+        }
+
+    # ------------------------------------------------------------------
+    # Distributions
+    # ------------------------------------------------------------------
+
+    def _apply_unimix(self, logits: torch.Tensor) -> torch.Tensor:
+        """Mix the softmax output with a uniform distribution.
+
+        Returns logits of the mixed distribution, so downstream code can keep
+        working with logits rather than probabilities.
+        """
+        if self.unimix <= 0.0:
+            return logits
+        probs = torch.softmax(logits, dim=-1)
+        uniform = torch.ones_like(probs) / float(self.latent_classes)
+        mixed = (1.0 - self.unimix) * probs + self.unimix * uniform
+        return torch.log(mixed)
+
+    def get_dist(self, logits: torch.Tensor) -> distributions.Independent:
+        """Return the factorized categorical distribution over the latent."""
+        base = distributions.OneHotCategoricalStraightThrough(logits=logits)
+        return distributions.Independent(base, 1)
+
+    def _sample(self, logits: torch.Tensor) -> torch.Tensor:
+        """Draw a straight-through one-hot sample from the latent distribution."""
+        probs = torch.softmax(logits, dim=-1)
+        index = torch.multinomial(
+            probs.reshape(-1, self.latent_classes), num_samples=1
+        ).reshape(*probs.shape[:-1])
+        sample = torch.nn.functional.one_hot(index, self.latent_classes).to(probs.dtype)
+        # Straight-through: hard sample forward, soft probabilities backward.
+        return sample + probs - probs.detach()
+
+    def _stats(self, logits: torch.Tensor) -> torch.Tensor:
+        return self._apply_unimix(
+            logits.reshape(*logits.shape[:-1], self.latent_dim, self.latent_classes)
+        )
+
+    # ------------------------------------------------------------------
+    # Transition steps
+    # ------------------------------------------------------------------
+
+    def imagine_step(
+        self,
+        prev_state: dict,
+        prev_action: torch.Tensor,
+        is_first: torch.Tensor | None = None,
+    ) -> dict:
+        """Advance the state one step using only the dynamics predictor.
+
+        Args:
+            prev_state: Previous model state.
+            prev_action: Previous action, shape ``(B, action_size)``.
+            is_first: Optional ``(B, 1)`` mask; where it is 1 the previous state
+                and action are zeroed, which resets the model at episode starts.
+
+        Returns:
+            The prior state ``{logit, stoch, deter}``.
+        """
+        prev_stoch = prev_state["stoch"]
+        prev_deter = prev_state["deter"]
+
+        if is_first is not None:
+            keep = (1.0 - is_first).to(prev_deter.dtype)
+            prev_action = prev_action * keep
+            prev_stoch = prev_stoch * keep.unsqueeze(-1)
+            prev_deter = prev_deter * keep
+
+        flat_stoch = prev_stoch.reshape(*prev_stoch.shape[:-2], self.stoch_size)
+        gru_in = self.gru_input(
+            torch.cat([flat_stoch, prev_action, prev_deter], dim=-1)
+        )
+        deter = self.gru(gru_in, prev_deter)
+
+        logit = self._stats(self.prior_net(deter))
+        return dict(logit=logit, stoch=self._sample(logit), deter=deter)
+
+    def observe_step(
+        self,
+        prev_state: dict,
+        prev_action: torch.Tensor,
+        embed: torch.Tensor,
+        is_first: torch.Tensor | None = None,
+    ) -> Tuple[dict, dict]:
+        """Advance the state one step using an observation embedding.
+
+        Returns:
+            ``(posterior, prior)``. Both share the deterministic state because
+            the sequence model is advanced exactly once per timestep.
+        """
+        prior = self.imagine_step(prev_state, prev_action, is_first)
+        logit = self._stats(
+            self.posterior_net(torch.cat([prior["deter"], embed], dim=-1))
+        )
+        posterior = dict(logit=logit, stoch=self._sample(logit), deter=prior["deter"])
+        return posterior, prior
+
+    # ------------------------------------------------------------------
+    # Rollouts
+    # ------------------------------------------------------------------
+
+    def observe_rollout(
+        self,
+        embed: torch.Tensor,
+        actions: torch.Tensor,
+        is_first: torch.Tensor,
+        init_state: dict,
+    ) -> Tuple[dict, dict]:
+        """Run the model over a batch of observed sequences.
+
+        Args:
+            embed: Observation embeddings, shape ``(T, B, embed_size)``.
+            actions: Actions ``a_{t-1}``, shape ``(T, B, action_size)``.
+            is_first: Episode-start flags, shape ``(T, B, 1)``.
+            init_state: State to start from, typically ``init_state(B, device)``.
+
+        Returns:
+            ``(posterior, prior)`` dicts with tensors of shape ``(T, B, ...)``.
+        """
+        seq_len = embed.shape[0]
+        posteriors: list[dict] = []
+        priors: list[dict] = []
+        state = init_state
+
+        for t in range(seq_len):
+            posterior, prior = self.observe_step(
+                state, actions[t], embed[t], is_first[t]
+            )
+            posteriors.append(posterior)
+            priors.append(prior)
+            state = posterior
+
+        keys = ("logit", "stoch", "deter")
+        if not posteriors:
+            empty = {key: init_state[key].unsqueeze(0)[:0] for key in keys}
+            return empty, empty
+
+        stacked_post = {
+            key: torch.stack([item[key] for item in posteriors], dim=0) for key in keys
+        }
+        stacked_prior = {
+            key: torch.stack([item[key] for item in priors], dim=0) for key in keys
+        }
+        return stacked_post, stacked_prior
+
+    def imagine_rollout(
+        self,
+        policy: Any,
+        init_state: dict,
+        horizon: int,
+    ) -> Tuple[dict, torch.Tensor]:
+        """Roll the dynamics forward under ``policy`` without observations.
+
+        Args:
+            policy: Callable mapping features to an action tensor.
+            init_state: Starting state, shape ``(B, ...)``.
+            horizon: Number of steps to imagine.
+
+        Returns:
+            ``(states, actions)`` where ``states`` holds ``horizon + 1`` entries
+            (the starting state followed by each imagined state) and ``actions``
+            has shape ``(horizon, B, action_size)``. Including the start state
+            lets the caller evaluate the policy on the state it acted from.
+        """
+        keys = ("logit", "stoch", "deter")
+        states: list[dict] = [init_state]
+        actions: list[torch.Tensor] = []
+        state = init_state
+
+        for _ in range(horizon):
+            action = policy(self.get_feat(state))
+            state = self.imagine_step(state, action)
+            actions.append(action)
+            states.append(state)
+
+        stacked = {
+            key: torch.stack([item[key] for item in states], dim=0) for key in keys
+        }
+        return stacked, torch.stack(actions, dim=0)
+
+    def kl_divergence(
+        self,
+        posterior_logit: torch.Tensor,
+        prior_logit: torch.Tensor,
+    ) -> torch.Tensor:
+        """KL between two factorized categorical latents, summed over factors."""
+        post = distributions.Independent(
+            distributions.OneHotCategorical(logits=posterior_logit), 1
+        )
+        prior = distributions.Independent(
+            distributions.OneHotCategorical(logits=prior_logit), 1
+        )
+        return distributions.kl.kl_divergence(post, prior)

--- a/world_models/models/dreamer.py
+++ b/world_models/models/dreamer.py
@@ -92,6 +92,20 @@ def _resolve_image_size(args: Any) -> tuple:
     raise ValueError(f"Invalid image_size={size}. Expected int or (H, W).")
 
 
+def _has_discrete_actions(env: Any) -> bool:
+    """Whether an environment exposes a discrete action space.
+
+    Checked structurally rather than with ``isinstance`` so that this module
+    does not need to import Gym at call time.
+    """
+    action_space = getattr(env, "action_space", None)
+    return (
+        action_space is not None
+        and hasattr(action_space, "n")
+        and not hasattr(action_space, "low")
+    )
+
+
 def make_env(args: Any) -> Any:
     """Construct a Dreamer-compatible environment from `DreamerConfig` options.
 
@@ -216,7 +230,14 @@ def make_env(args: Any) -> Any:
         )
 
     env = env_wrapper.ActionRepeat(env, int(args.action_repeat))
-    env = env_wrapper.NormalizeActions(env)
+    if _has_discrete_actions(env):
+        # Discrete backends (Atari, Procgen, BSuite, DMLab) are exposed to the
+        # agent as one-hot vectors, which keeps a single continuous-looking
+        # action interface across every backend. Action normalization would
+        # remap the [0, 1] one-hot space and is skipped.
+        env = env_wrapper.OneHotAction(env)
+    else:
+        env = env_wrapper.NormalizeActions(env)
     frame_stack = max(1, int(getattr(args, "frame_stack", 1)))
     if frame_stack > 1:
         env = env_wrapper.FrameStack(env, frame_stack)
@@ -995,10 +1016,56 @@ class DreamerAgent(ExportableAgentMixin):
 
     It builds environments from config, initializes seeds and logging,
     instantiates `Dreamer`, and exposes simple `train()` / `evaluate()` methods.
+
+    Subclasses select a different algorithm by overriding `_config_cls` and
+    `_build_core`; everything else (environments, seeding, logging, checkpoint
+    cadence) is shared. See `world_models.models.dreamer_v3.DreamerV3Agent`.
     """
 
+    _config_cls: type[DreamerConfig] = DreamerConfig
+
+    @classmethod
+    def _coerce_config(cls, config: Any | None) -> Any:
+        """Normalize config inputs to this agent's configuration class."""
+
+        config_cls = cls._config_cls
+        if config is None:
+            return config_cls()
+        if isinstance(config, config_cls):
+            return config
+        if isinstance(config, dict):
+            return config_cls.from_dict(config)
+        if isinstance(config, (str, Path)):
+            return config_cls.from_yaml(config)
+        if isinstance(config, DreamerConfig):
+            # Upgrade a base config to the subclass. Only fields the caller
+            # actually changed are carried over: copying every shared field
+            # would silently overwrite the subclass's own tuned defaults with
+            # the base class's (for example dropping DreamerV3's discount of
+            # 0.997 back to 0.99), which is exactly what a versioned config is
+            # supposed to prevent.
+            base_defaults = type(config)().to_dict()
+            changed = {
+                key: value
+                for key, value in config.to_dict().items()
+                if key in config_cls.__dataclass_fields__
+                and base_defaults.get(key) != value
+            }
+            return config_cls.from_dict(changed)
+        raise TypeError(
+            f"config must be a {config_cls.__name__}, dict, YAML path/string, "
+            f"or None; got {type(config).__name__}."
+        )
+
+    def _build_core(
+        self, obs_shape: Any, action_size: int, device: torch.device
+    ) -> Any:
+        """Instantiate the algorithm core that this agent drives."""
+
+        return Dreamer(self.args, obs_shape, action_size, device, self.args.restore)
+
     def __init__(self, config: Any = None, **kwargs: Any) -> None:
-        self.args = _coerce_dreamer_config(config)
+        self.args = self._coerce_config(config)
 
         self.last_latents_ref = kwargs.get("last_latents_ref", None)
 
@@ -1081,9 +1148,7 @@ class DreamerAgent(ExportableAgentMixin):
 
         obs_shape = self.train_env.observation_space["image"].shape
         action_size = self.train_env.action_space.shape[0]
-        self.dreamer = Dreamer(
-            self.args, obs_shape, action_size, device, self.args.restore
-        )
+        self.dreamer = self._build_core(obs_shape, action_size, device)
 
         self.logger = Logger(
             self.logdir,
@@ -1106,7 +1171,7 @@ class DreamerAgent(ExportableAgentMixin):
     ) -> "DreamerAgent":
         """Build a high-level Dreamer agent from a config object, dict, or YAML file."""
 
-        return cls(_apply_config_overrides(_coerce_dreamer_config(config), overrides))
+        return cls(_apply_config_overrides(cls._coerce_config(config), overrides))
 
     @classmethod
     def from_pretrained(
@@ -1146,9 +1211,9 @@ class DreamerAgent(ExportableAgentMixin):
             checkpoint.get("config") if isinstance(checkpoint, dict) else None
         )
         if config is None and checkpoint_config is not None:
-            args = _coerce_dreamer_config(checkpoint_config)
+            args = cls._coerce_config(checkpoint_config)
         elif config is not None:
-            args = _coerce_dreamer_config(config)
+            args = cls._coerce_config(config)
         else:
             config_path = _resolve_pretrained_file(
                 pretrained_model_name_or_path,
@@ -1161,7 +1226,7 @@ class DreamerAgent(ExportableAgentMixin):
                     "No config was provided and no config YAML was found beside "
                     f"{pretrained_model_name_or_path!r}."
                 )
-            args = DreamerConfig.from_yaml(config_path)
+            args = cls._config_cls.from_yaml(config_path)
         args = _apply_config_overrides(args, overrides)
         args.restore = False
         agent = cls(args)
@@ -1245,6 +1310,9 @@ class DreamerAgent(ExportableAgentMixin):
                     "replay/episodes": self.dreamer.data_buffer.episodes,
                 }
             )
+            # Algorithm cores may publish extra diagnostics (DreamerV3 reports
+            # its individual loss terms, gradient norms, and return scale).
+            logs.update(getattr(self.dreamer, "last_metrics", {}) or {})
 
             stats_freq = getattr(self.args, "log_system_stats_freq", 0)
             if stats_freq and global_step % stats_freq == 0:

--- a/world_models/models/dreamer_v3.py
+++ b/world_models/models/dreamer_v3.py
@@ -1,0 +1,1054 @@
+"""DreamerV3: a general world-model agent with fixed hyperparameters.
+
+DreamerV3 learns a world model from replayed experience and improves its policy
+purely on trajectories imagined by that model. Relative to DreamerV2 the changes
+that matter are robustness techniques rather than architecture search:
+
+============================  ====================================================
+Technique                     Effect
+============================  ====================================================
+Categorical latents + unimix  Well-behaved KL terms, no deterministic collapse
+Free bits on KL terms         A small representation loss without collapse
+symexp two-hot reward/critic  Gradient scale decoupled from target scale
+Percentile return norm        One entropy scale works for sparse and dense rewards
+Critic EMA + replay loss      Stable bootstrapping, better values under hard rewards
+LaProp + adaptive clipping    Loss-scale-independent optimization
+============================  ====================================================
+
+The class exposes the same surface as :class:`~world_models.models.dreamer.Dreamer`
+(``world_model_loss``, ``train_one_batch``, ``act_and_collect_data``,
+``evaluate``, ``save``, ``restore_checkpoint``), so
+:class:`~world_models.models.dreamer.DreamerAgent`'s training loop drives it
+without modification.
+
+Reference:
+    Mastering Diverse Domains through World Models
+    Hafner et al., 2023 - https://arxiv.org/abs/2301.04104
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from world_models.configs.dreamer_v3_config import DreamerV3Config
+from world_models.memory.dreamer_v3_memory import DreamerV3ReplayBuffer
+from world_models.models.categorical_rssm import CategoricalRSSM
+from world_models.models.dreamer import (
+    DreamerAgent,
+    _apply_config_overrides,
+    _resolve_pretrained_file,
+    _save_config_next_to_checkpoint,
+    get_available_memory,
+    make_env,
+)
+from world_models.optim import LaProp, adaptive_grad_clip_
+from world_models.utils.dreamer_utils import FreezeParameters
+from world_models.utils.dreamer_v3_utils import (
+    ReturnNormalizer,
+    free_bits,
+    lambda_return,
+)
+from world_models.utils.logging_utils import assert_finite, get_package_logger
+from world_models.vision.dreamer_v3_nets import (
+    DreamerV3Actor,
+    DreamerV3Decoder,
+    DreamerV3Encoder,
+    DreamerV3Head,
+    preprocess_image,
+)
+
+logger = get_package_logger(__name__)
+
+__all__ = ["DreamerV3", "DreamerV3Agent", "coerce_dreamer_v3_config"]
+
+
+def coerce_dreamer_v3_config(config: Any | None) -> DreamerV3Config:
+    """Normalize config inputs to a :class:`DreamerV3Config` instance."""
+    if config is None:
+        return DreamerV3Config()
+    if isinstance(config, DreamerV3Config):
+        return config
+    if isinstance(config, dict):
+        return DreamerV3Config.from_dict(config)
+    if isinstance(config, (str, Path)):
+        return DreamerV3Config.from_yaml(config)
+    raise TypeError(
+        "config must be a DreamerV3Config, dict, YAML path/string, or None; "
+        f"got {type(config).__name__}."
+    )
+
+
+class DreamerV3:
+    """World model, actor, and critic trained together from replayed experience.
+
+    Args:
+        args: A :class:`DreamerV3Config` (or any object exposing the same
+            attributes).
+        obs_shape: Observation shape, ``(C, H, W)`` or ``(D,)``.
+        action_size: Number of discrete actions, or continuous action dimension.
+        device: Torch device to place the modules on.
+        restore: Whether to restore from ``args.checkpoint_path`` after building.
+    """
+
+    def __init__(
+        self,
+        args: Any,
+        obs_shape: Any,
+        action_size: int,
+        device: torch.device | str,
+        restore: bool = False,
+    ) -> None:
+        self.args = args
+        self.obs_shape = tuple(int(dim) for dim in obs_shape)
+        self.action_size = int(action_size)
+        self.device = torch.device(device)
+        self.restore = bool(restore)
+        self.restore_path = getattr(args, "checkpoint_path", "")
+        self.is_image_obs = len(self.obs_shape) == 3
+        self.discrete_actions = str(getattr(args, "actor_dist", "auto")) == "onehot"
+        self.last_metrics: dict[str, float] = {}
+
+        obs_dtype = np.uint8 if self.is_image_obs else np.float32
+        bytes_per_obs = int(np.prod(self.obs_shape)) * np.dtype(obs_dtype).itemsize
+        # actions + reward + is_terminal + is_first
+        bytes_per_sample = bytes_per_obs + self.action_size * 4 + 12
+        max_buffer_size = int(
+            (get_available_memory() * 0.8) // max(1, bytes_per_sample)
+        )
+        buffer_size = min(int(args.buffer_size), max_buffer_size)
+        if buffer_size < int(args.buffer_size):
+            logger.warning(
+                "Reducing replay capacity from %s to %s due to memory constraints.",
+                args.buffer_size,
+                buffer_size,
+            )
+
+        self.data_buffer = DreamerV3ReplayBuffer(
+            size=buffer_size,
+            obs_shape=self.obs_shape,
+            action_size=self.action_size,
+            seq_len=int(args.train_seq_len),
+            batch_size=int(args.batch_size),
+            obs_dtype=obs_dtype,
+            online_fraction=float(getattr(args, "online_fraction", 0.5)),
+        )
+
+        self.use_amp = bool(
+            getattr(args, "use_amp", False) and self.device.type == "cuda"
+        )
+        self.return_norm = ReturnNormalizer(
+            decay=float(args.return_norm_decay),
+            limit=float(args.return_norm_limit),
+            low=float(args.return_norm_low),
+            high=float(args.return_norm_high),
+        )
+        self._build_model(restore=self.restore)
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    def _build_model(self, restore: bool = False) -> None:
+        args = self.args
+        hidden = args.resolved_hidden_size
+        deter = args.resolved_recurrent_units
+        classes = args.resolved_latent_classes
+        depth = args.resolved_cnn_depth
+
+        self.obs_encoder = DreamerV3Encoder(
+            self.obs_shape,
+            cnn_depth=depth,
+            hidden_size=hidden,
+            mlp_layers=int(args.mlp_layers),
+            activation=str(args.activation),
+        ).to(self.device)
+
+        self.rssm = CategoricalRSSM(
+            action_size=self.action_size,
+            embed_size=self.obs_encoder.embed_size,
+            latent_dim=int(args.latent_dim),
+            latent_classes=classes,
+            deter_size=deter,
+            hidden_size=hidden,
+            gru_blocks=int(args.gru_blocks),
+            unimix=float(args.unimix),
+            activation=str(args.activation),
+        ).to(self.device)
+
+        feature_size = self.rssm.feature_size
+        self.obs_decoder = DreamerV3Decoder(
+            feature_size,
+            self.obs_shape,
+            encoder=self.obs_encoder,
+            cnn_depth=depth,
+            hidden_size=hidden,
+            mlp_layers=int(args.mlp_layers),
+            activation=str(args.activation),
+        ).to(self.device)
+
+        head_kwargs: dict[str, Any] = dict(
+            layers=int(args.mlp_layers),
+            units=hidden,
+            num_bins=int(args.num_buckets),
+            symlog_range=float(args.symlog_range),
+            activation=str(args.activation),
+        )
+        self.reward_model = DreamerV3Head(
+            feature_size, dist="symexp_twohot", zero_init_output=True, **head_kwargs
+        ).to(self.device)
+        self.continue_model = DreamerV3Head(
+            feature_size, dist="binary", zero_init_output=False, **head_kwargs
+        ).to(self.device)
+        self.value_model = DreamerV3Head(
+            feature_size, dist="symexp_twohot", zero_init_output=True, **head_kwargs
+        ).to(self.device)
+        # Slow-moving copy of the critic used as a regularization target. It is
+        # never optimized directly, so its gradients stay disabled.
+        self.slow_value_model = copy.deepcopy(self.value_model).to(self.device)
+        for param in self.slow_value_model.parameters():
+            param.requires_grad_(False)
+
+        self.actor = DreamerV3Actor(
+            feature_size,
+            self.action_size,
+            discrete=self.discrete_actions,
+            layers=int(args.mlp_layers),
+            units=hidden,
+            unimix=float(args.unimix),
+            min_std=float(args.actor_min_std),
+            max_std=float(args.actor_max_std),
+            activation=str(args.activation),
+        ).to(self.device)
+
+        self.world_model_modules: list[nn.Module] = [
+            self.rssm,
+            self.obs_encoder,
+            self.obs_decoder,
+            self.reward_model,
+            self.continue_model,
+        ]
+        self.actor_modules: list[nn.Module] = [self.actor]
+        self.value_modules: list[nn.Module] = [self.value_model]
+
+        self.world_model_params = [
+            param
+            for module in self.world_model_modules
+            for param in module.parameters()
+        ]
+
+        # DreamerV3 uses one learning rate and one optimizer configuration for
+        # the world model, the actor, and the critic alike.
+        def make_optimizer(parameters: list[torch.nn.Parameter]) -> LaProp:
+            return LaProp(
+                parameters,
+                lr=float(args.learning_rate),
+                betas=(float(args.opt_beta1), float(args.opt_beta2)),
+                eps=float(args.opt_eps),
+                weight_decay=float(args.weight_decay),
+            )
+
+        self.world_model_opt = make_optimizer(self.world_model_params)
+        self.actor_opt = make_optimizer(list(self.actor.parameters()))
+        self.value_opt = make_optimizer(list(self.value_model.parameters()))
+
+        self.world_model_scaler = torch.amp.GradScaler("cuda", enabled=self.use_amp)
+        self.actor_scaler = torch.amp.GradScaler("cuda", enabled=self.use_amp)
+        self.value_scaler = torch.amp.GradScaler("cuda", enabled=self.use_amp)
+
+        self._updates = 0
+        if restore and self.restore_path:
+            self.restore_checkpoint(self.restore_path)
+
+    @classmethod
+    def from_config(
+        cls,
+        config: Any = None,
+        *,
+        obs_shape: tuple[int, ...] | None = None,
+        action_size: int | None = None,
+        device: str | torch.device | None = None,
+        restore: bool | None = None,
+        **overrides: Any,
+    ) -> "DreamerV3":
+        """Build a DreamerV3 core model from a config object, dict, or YAML file.
+
+        When ``obs_shape`` or ``action_size`` is omitted, a temporary environment
+        is constructed from the config to infer them.
+        """
+        args = cast(
+            DreamerV3Config,
+            _apply_config_overrides(coerce_dreamer_v3_config(config), overrides),
+        )
+        args.resolve()
+        if obs_shape is None or action_size is None:
+            env = make_env(args)
+            if obs_shape is None:
+                obs_shape = tuple(env.observation_space["image"].shape)
+            if action_size is None:
+                action_size = int(env.action_space.shape[0])
+            if str(args.actor_dist) == "auto":
+                args.actor_dist = _resolve_actor_dist(env)
+        if str(args.actor_dist) == "auto":
+            args.actor_dist = "normal"
+
+        if device is not None:
+            torch_device = torch.device(device)
+        elif torch.cuda.is_available() and not args.no_gpu:
+            torch_device = torch.device("cuda")
+        else:
+            torch_device = torch.device("cpu")
+        should_restore = args.restore if restore is None else restore
+        return cls(args, obs_shape, action_size, torch_device, should_restore)
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str | Path,
+        *,
+        config: Any = None,
+        checkpoint_filename: str | None = None,
+        config_filename: str = "config.yaml",
+        repo_type: str | None = None,
+        revision: str | None = None,
+        map_location: str | torch.device | None = None,
+        **overrides: Any,
+    ) -> "DreamerV3":
+        """Load a DreamerV3 checkpoint from a local path/directory or the HF Hub."""
+        candidates = (
+            (checkpoint_filename,)
+            if checkpoint_filename is not None
+            else ("model.pt", "pytorch_model.bin", "checkpoint.pt", "ckpt.pt")
+        )
+        checkpoint_path = _resolve_pretrained_file(
+            pretrained_model_name_or_path,
+            candidates,
+            repo_type=repo_type,
+            revision=revision,
+        )
+        if checkpoint_path is None:
+            raise FileNotFoundError(
+                "Could not find a DreamerV3 checkpoint for "
+                f"{pretrained_model_name_or_path!r}."
+            )
+
+        checkpoint = torch.load(
+            checkpoint_path, map_location=map_location or "cpu", weights_only=True
+        )
+        checkpoint_config = (
+            checkpoint.get("config") if isinstance(checkpoint, dict) else None
+        )
+        if config is not None:
+            args = coerce_dreamer_v3_config(config)
+        elif checkpoint_config is not None:
+            args = coerce_dreamer_v3_config(checkpoint_config)
+        else:
+            config_path = _resolve_pretrained_file(
+                pretrained_model_name_or_path,
+                (config_filename, "dreamer_v3_config.yaml", "config.yml"),
+                repo_type=repo_type,
+                revision=revision,
+            )
+            if config_path is None:
+                raise FileNotFoundError(
+                    "No config was provided and no config YAML was found beside "
+                    f"{pretrained_model_name_or_path!r}."
+                )
+            args = DreamerV3Config.from_yaml(config_path)
+        args = cast(DreamerV3Config, _apply_config_overrides(args, overrides))
+
+        obs_shape = (
+            checkpoint.get("obs_shape") if isinstance(checkpoint, dict) else None
+        )
+        action_size = (
+            checkpoint.get("action_size") if isinstance(checkpoint, dict) else None
+        )
+        model = cls.from_config(
+            args,
+            obs_shape=tuple(obs_shape) if obs_shape is not None else None,
+            action_size=int(action_size) if action_size is not None else None,
+            device=map_location,
+            restore=False,
+        )
+        model.restore_checkpoint(checkpoint_path, map_location=map_location)
+        return model
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    def _named_modules(self) -> dict[str, nn.Module]:
+        return {
+            "rssm": self.rssm,
+            "obs_encoder": self.obs_encoder,
+            "obs_decoder": self.obs_decoder,
+            "reward_model": self.reward_model,
+            "continue_model": self.continue_model,
+            "value_model": self.value_model,
+            "actor": self.actor,
+        }
+
+    def parameter_count(self, trainable_only: bool = False) -> int:
+        """Total number of parameters across the DreamerV3 modules."""
+        return sum(
+            param.numel()
+            for module in self._named_modules().values()
+            for param in module.parameters()
+            if not trainable_only or param.requires_grad
+        )
+
+    def summary(self) -> dict[str, Any]:
+        """Compact per-module parameter-count summary."""
+        modules = self._named_modules()
+        module_params = {
+            name: sum(param.numel() for param in module.parameters())
+            for name, module in modules.items()
+        }
+        trainable = {
+            name: sum(
+                param.numel() for param in module.parameters() if param.requires_grad
+            )
+            for name, module in modules.items()
+        }
+        return {
+            "total_parameters": sum(module_params.values()),
+            "trainable_parameters": sum(trainable.values()),
+            "modules": module_params,
+            "trainable_modules": trainable,
+        }
+
+    # ------------------------------------------------------------------
+    # Observation handling
+    # ------------------------------------------------------------------
+
+    def preprocess(self, obs: torch.Tensor) -> torch.Tensor:
+        """Map raw observations into the model's input space."""
+        if self.is_image_obs:
+            return preprocess_image(obs)
+        return obs.to(torch.float32)
+
+    # ------------------------------------------------------------------
+    # World model
+    # ------------------------------------------------------------------
+
+    @assert_finite
+    def world_model_loss(
+        self,
+        obs: torch.Tensor,
+        actions: torch.Tensor,
+        rewards: torch.Tensor,
+        is_terminal: torch.Tensor,
+        is_first: torch.Tensor,
+    ) -> tuple[torch.Tensor, dict]:
+        """Compute the world model loss over a batch of replayed sequences.
+
+        Args:
+            obs: ``(T, B, *obs_shape)`` raw observations.
+            actions: ``(T, B, action_size)`` actions taken at each observation.
+            rewards: ``(T, B)`` rewards received for those actions.
+            is_terminal: ``(T, B)`` true-termination flags.
+            is_first: ``(T, B)`` episode-start flags.
+
+        Returns:
+            ``(loss, posterior)`` where ``posterior`` holds the ``(T, B, ...)``
+            model states used for actor-critic learning.
+        """
+        args = self.args
+        processed = self.preprocess(obs)
+        embed = self.obs_encoder(processed)
+
+        # The sequence model consumes a_{t-1}, so shift the action sequence and
+        # pad the first step with zeros.
+        prev_actions = torch.cat([torch.zeros_like(actions[:1]), actions[:-1]], dim=0)
+
+        init_state = self.rssm.init_state(obs.shape[1], self.device)
+        posterior, prior = self.rssm.observe_rollout(
+            embed, prev_actions, is_first.unsqueeze(-1), init_state
+        )
+        features = self.rssm.get_feat(posterior)
+
+        reconstruction = self.obs_decoder(features)
+        recon_loss = self.obs_decoder.loss(reconstruction, processed)
+
+        reward_dist = self.reward_model(features)
+        reward_loss = -reward_dist.log_prob(rewards)
+
+        continue_dist = self.continue_model(features)
+        continue_loss = -continue_dist.log_prob(1.0 - is_terminal)
+
+        # Dynamics loss trains the prior towards the posterior; representation
+        # loss trains the posterior towards the prior. Free bits switch each off
+        # once it is already minimized below one nat.
+        dyn_loss = free_bits(
+            self.rssm.kl_divergence(posterior["logit"].detach(), prior["logit"]),
+            args.free_nats,
+        )
+        rep_loss = free_bits(
+            self.rssm.kl_divergence(posterior["logit"], prior["logit"].detach()),
+            args.free_nats,
+        )
+
+        prediction_loss = recon_loss + reward_loss + continue_loss
+        loss = (
+            float(args.beta_pred) * prediction_loss
+            + float(args.beta_dyn) * dyn_loss
+            + float(args.beta_rep) * rep_loss
+        ).mean()
+
+        self.last_metrics.update(
+            {
+                "wm/recon_loss": float(recon_loss.mean().detach()),
+                "wm/reward_loss": float(reward_loss.mean().detach()),
+                "wm/continue_loss": float(continue_loss.mean().detach()),
+                "wm/dyn_loss": float(dyn_loss.mean().detach()),
+                "wm/rep_loss": float(rep_loss.mean().detach()),
+            }
+        )
+        return loss, posterior
+
+    # ------------------------------------------------------------------
+    # Imagination and actor-critic
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def _imagine(self, posterior: dict) -> dict:
+        """Roll the world model forward under the current policy.
+
+        Everything here is computed without gradients: DreamerV3 uses the
+        Reinforce estimator, so the actor learns through ``log_prob`` of detached
+        actions rather than by backpropagating through the dynamics.
+
+        Indexing follows the replay buffer's convention throughout: the reward
+        and continuation heads are trained so that their prediction at a state
+        describes *leaving* that state. So for imagined states ``s_0 .. s_H``,
+        the reward for action ``a_t`` is ``rewards[t]`` and the episode survives
+        that transition with probability ``continues[t]`` -- both indexed by the
+        state acted from, not the state arrived at. Mixing the two conventions
+        shifts credit by one step and quietly corrupts every value estimate.
+
+        Returns:
+            A dict with the imagined features, returns, values, and the
+            discounted weights used to average the actor and critic objectives.
+        """
+        args = self.args
+        horizon = int(args.imagine_horizon)
+        discount = float(args.discount)
+
+        start = self.rssm.detach_state(self.rssm.seq_to_batch(posterior))
+        with FreezeParameters(self.world_model_modules + self.actor_modules):
+            states, actions = self.rssm.imagine_rollout(
+                lambda feat: self.actor(feat), start, horizon
+            )
+            features = self.rssm.get_feat(states)
+            rewards = self.reward_model(features).mean
+            continues = self.continue_model(features).probs
+            values = self.value_model(features).mean
+
+        discounts = discount * continues
+
+        returns = lambda_return(
+            rewards=rewards[:-1],
+            values=values[1:],
+            continues=discounts[:-1],
+            bootstrap=values[-1],
+            lambda_=float(args.td_lambda),
+        )
+
+        # Probability of reaching each imagined state and acting from it. The
+        # first state is a real replayed state, so it is reached with certainty.
+        weights = torch.cumprod(
+            torch.cat(
+                [torch.ones_like(discounts[:1]), discounts[: horizon - 1]], dim=0
+            ),
+            dim=0,
+        )
+
+        return {
+            "features": features,
+            "actions": actions,
+            "returns": returns,
+            "values": values,
+            "weights": weights,
+            "rewards": rewards,
+        }
+
+    @assert_finite
+    def actor_loss(self, imagined: dict) -> torch.Tensor:
+        """Reinforce objective with normalized returns and an entropy bonus."""
+        args = self.args
+        features = imagined["features"][:-1]
+        actions = imagined["actions"]
+        returns = imagined["returns"]
+        values = imagined["values"][:-1]
+        weights = imagined["weights"]
+
+        denominator = self.return_norm.update(returns)
+        advantage = ((returns - values) / denominator).detach()
+
+        dist = self.actor.dist(features)
+        log_prob = dist.log_prob(actions)
+        entropy = dist.entropy()
+
+        objective = log_prob * advantage + float(args.actor_entropy) * entropy
+        loss = -(weights * objective).mean()
+
+        self.last_metrics.update(
+            {
+                "actor/entropy": float(entropy.mean().detach()),
+                "actor/advantage": float(advantage.mean()),
+                "actor/return_scale": self.return_norm.scale,
+                "actor/imag_reward": float(imagined["rewards"].mean()),
+            }
+        )
+        return loss
+
+    @assert_finite
+    def value_loss(
+        self,
+        imagined: dict,
+        replay: dict | None = None,
+    ) -> torch.Tensor:
+        """Two-hot critic loss on imagined returns, plus regularizers.
+
+        The critic is regularized towards an exponential moving average of its
+        own weights, and optionally also fit to lambda-returns computed over
+        replayed rewards.
+        """
+        args = self.args
+        features = imagined["features"][:-1].detach()
+        targets = imagined["returns"].detach()
+        weights = imagined["weights"]
+
+        dist = self.value_model(features)
+        loss = -dist.log_prob(targets)
+
+        if float(args.critic_ema_regularizer) > 0.0:
+            with torch.no_grad():
+                slow_dist = self.slow_value_model(features)
+            loss = loss + float(args.critic_ema_regularizer) * dist.cross_entropy_to(
+                slow_dist
+            )
+
+        total = float(args.critic_loss_scale) * (weights * loss).mean()
+
+        if replay is not None and float(args.critic_replay_loss_scale) > 0.0:
+            replay_dist = self.value_model(replay["features"])
+            replay_loss = -replay_dist.log_prob(replay["returns"])
+            total = total + float(args.critic_replay_loss_scale) * replay_loss.mean()
+            self.last_metrics["critic/replay_loss"] = float(replay_loss.mean().detach())
+
+        self.last_metrics.update(
+            {
+                "critic/value": float(imagined["values"].mean()),
+                "critic/target": float(targets.mean()),
+            }
+        )
+        return total
+
+    @torch.no_grad()
+    def _replay_value_targets(
+        self,
+        posterior: dict,
+        rewards: torch.Tensor,
+        is_terminal: torch.Tensor,
+        imagined: dict,
+    ) -> dict:
+        """Build lambda-return targets over the replayed rewards.
+
+        The imagination returns at the start states act as on-policy value
+        annotations for the replayed states; lambda-returns are then accumulated
+        over the actual replayed rewards.
+
+        Indexing matches :meth:`_imagine`: ``rewards[t]`` and ``is_terminal[t]``
+        describe leaving replayed state ``t``, so they pair with the value
+        annotation of state ``t + 1``.
+        """
+        seq_len, batch = rewards.shape
+        features = self.rssm.get_feat(self.rssm.detach_state(posterior))
+        annotations = imagined["returns"][0].reshape(seq_len, batch)
+        discounts = float(self.args.discount) * (1.0 - is_terminal)
+
+        returns = lambda_return(
+            rewards=rewards[:-1],
+            values=annotations[1:],
+            continues=discounts[:-1],
+            bootstrap=annotations[-1],
+            lambda_=float(self.args.td_lambda),
+        )
+        return {"features": features[:-1].detach(), "returns": returns.detach()}
+
+    # ------------------------------------------------------------------
+    # Optimization
+    # ------------------------------------------------------------------
+
+    def _optimize(
+        self,
+        loss: torch.Tensor,
+        optimizer: LaProp,
+        scaler: Any,
+        parameters: list[torch.nn.Parameter],
+        name: str,
+    ) -> None:
+        optimizer.zero_grad(set_to_none=True)
+        scaler.scale(loss).backward()
+        scaler.unscale_(optimizer)
+        grad_norm = adaptive_grad_clip_(
+            parameters,
+            clip=float(self.args.agc_clip),
+            eps=float(self.args.agc_eps),
+        )
+        self.last_metrics[f"grad_norm/{name}"] = float(grad_norm)
+        scaler.step(optimizer)
+        scaler.update()
+
+    def _update_slow_critic(self) -> None:
+        decay = float(self.args.critic_ema_decay)
+        with torch.no_grad():
+            for slow, fast in zip(
+                self.slow_value_model.parameters(), self.value_model.parameters()
+            ):
+                slow.mul_(decay).add_(fast.detach(), alpha=1.0 - decay)
+
+    def train_one_batch(self) -> list[float]:
+        """Run one world model, actor, and critic update.
+
+        Returns:
+            ``[model_loss, actor_loss, value_loss]`` as plain floats, matching
+            the contract expected by the shared Dreamer training loop.
+        """
+        if not self.data_buffer.can_sample:
+            return [0.0, 0.0, 0.0]
+
+        obs, actions, rewards, is_terminal, is_first = self.data_buffer.sample()
+        obs_t = torch.as_tensor(obs, device=self.device)
+        actions_t = torch.as_tensor(actions, dtype=torch.float32, device=self.device)
+        rewards_t = torch.as_tensor(rewards, dtype=torch.float32, device=self.device)
+        terminal_t = torch.as_tensor(
+            is_terminal, dtype=torch.float32, device=self.device
+        )
+        first_t = torch.as_tensor(is_first, dtype=torch.float32, device=self.device)
+
+        device_type = self.device.type
+        with torch.amp.autocast(device_type=device_type, enabled=self.use_amp):
+            model_loss, posterior = self.world_model_loss(
+                obs_t, actions_t, rewards_t, terminal_t, first_t
+            )
+        self._optimize(
+            model_loss,
+            self.world_model_opt,
+            self.world_model_scaler,
+            self.world_model_params,
+            "world_model",
+        )
+
+        imagined = self._imagine(posterior)
+
+        with torch.amp.autocast(device_type=device_type, enabled=self.use_amp):
+            actor_loss = self.actor_loss(imagined)
+        self._optimize(
+            actor_loss,
+            self.actor_opt,
+            self.actor_scaler,
+            list(self.actor.parameters()),
+            "actor",
+        )
+
+        replay_targets = None
+        if float(self.args.critic_replay_loss_scale) > 0.0:
+            replay_targets = self._replay_value_targets(
+                posterior, rewards_t, terminal_t, imagined
+            )
+        with torch.amp.autocast(device_type=device_type, enabled=self.use_amp):
+            value_loss = self.value_loss(imagined, replay_targets)
+        self._optimize(
+            value_loss,
+            self.value_opt,
+            self.value_scaler,
+            list(self.value_model.parameters()),
+            "critic",
+        )
+
+        self._update_slow_critic()
+        self._updates += 1
+
+        return [
+            float(model_loss.detach()),
+            float(actor_loss.detach()),
+            float(value_loss.detach()),
+        ]
+
+    # ------------------------------------------------------------------
+    # Environment interaction
+    # ------------------------------------------------------------------
+
+    def _obs_to_tensor(self, obs: Any) -> torch.Tensor:
+        array = obs["image"] if isinstance(obs, dict) else obs
+        tensor = torch.as_tensor(np.asarray(array).copy(), device=self.device)
+        return tensor.unsqueeze(0)
+
+    def act_with_world_model(
+        self,
+        obs: Any,
+        prev_state: dict,
+        prev_action: torch.Tensor,
+        explore: bool = False,
+        is_first: bool = False,
+    ) -> tuple[dict, torch.Tensor]:
+        """Update the model state with a new observation and choose an action."""
+        obs_t = self.preprocess(self._obs_to_tensor(obs))
+        embed = self.obs_encoder(obs_t)
+        first = torch.full(
+            (1, 1), float(is_first), device=self.device, dtype=torch.float32
+        )
+        posterior, _ = self.rssm.observe_step(prev_state, prev_action, embed, first)
+        features = self.rssm.get_feat(posterior)
+        action = self.actor(features, deterministic=not explore)
+        if explore:
+            action = self.actor.add_exploration(
+                action, float(getattr(self.args, "action_noise", 0.0))
+            )
+        return posterior, action
+
+    def _initial_action(self) -> torch.Tensor:
+        return torch.zeros(1, self.action_size, device=self.device)
+
+    def act_and_collect_data(self, env: Any, collect_steps: int) -> np.ndarray:
+        """Interact with ``env`` under the current policy, filling the buffer."""
+        obs = env.reset()
+        prev_state = self.rssm.init_state(1, self.device)
+        prev_action = self._initial_action()
+        is_first = True
+        episode_rewards = [0.0]
+
+        for step in range(collect_steps):
+            with torch.no_grad():
+                posterior, action = self.act_with_world_model(
+                    obs, prev_state, prev_action, explore=True, is_first=is_first
+                )
+            action_np = action[0].cpu().numpy()
+            next_obs, reward, done, info = env.step(action_np)
+            executed = (
+                info["action"]
+                if isinstance(info, dict) and "action" in info
+                else action_np
+            )
+            terminal = _is_true_termination(info, done)
+            self.data_buffer.add(obs, executed, reward, done, is_terminal=terminal)
+            episode_rewards[-1] += reward
+
+            if done:
+                obs = env.reset()
+                prev_state = self.rssm.init_state(1, self.device)
+                prev_action = self._initial_action()
+                is_first = True
+                if step != collect_steps - 1:
+                    episode_rewards.append(0.0)
+            else:
+                obs = next_obs
+                prev_state = posterior
+                prev_action = torch.as_tensor(
+                    np.asarray(executed, dtype=np.float32), device=self.device
+                ).reshape(1, self.action_size)
+                is_first = False
+
+        return np.array(episode_rewards)
+
+    def collect_random_episodes(self, env: Any, seed_steps: int) -> np.ndarray:
+        """Fill the buffer with uniformly random actions before training starts."""
+        obs = env.reset()
+        episode_rewards = [0.0]
+
+        for step in range(seed_steps):
+            action = env.action_space.sample()
+            next_obs, reward, done, info = env.step(action)
+            executed = (
+                info["action"]
+                if isinstance(info, dict) and "action" in info
+                else action
+            )
+            terminal = _is_true_termination(info, done)
+            self.data_buffer.add(obs, executed, reward, done, is_terminal=terminal)
+            episode_rewards[-1] += reward
+            if done:
+                obs = env.reset()
+                if step != seed_steps - 1:
+                    episode_rewards.append(0.0)
+            else:
+                obs = next_obs
+
+        return np.array(episode_rewards)
+
+    def evaluate(
+        self, env: Any, eval_episodes: int, render: bool = False
+    ) -> tuple[np.ndarray, np.ndarray, Any]:
+        """Run greedy evaluation episodes and optionally capture frames."""
+        episode_rewards = np.zeros(eval_episodes)
+        video_images: list[list[Any]] = [[] for _ in range(eval_episodes)]
+        latents: list[Any] | None = [] if render else None
+
+        for episode in range(eval_episodes):
+            obs = env.reset()
+            done = False
+            prev_state = self.rssm.init_state(1, self.device)
+            prev_action = self._initial_action()
+            is_first = True
+
+            while not done:
+                with torch.no_grad():
+                    posterior, action = self.act_with_world_model(
+                        obs, prev_state, prev_action, explore=False, is_first=is_first
+                    )
+                action_np = action[0].cpu().numpy()
+                next_obs, reward, done, info = env.step(action_np)
+                executed = (
+                    info["action"]
+                    if isinstance(info, dict) and "action" in info
+                    else action_np
+                )
+                episode_rewards[episode] += reward
+
+                if render:
+                    image = obs["image"] if isinstance(obs, dict) else obs
+                    if np.asarray(image).ndim == 3:
+                        video_images[episode].append(
+                            np.asarray(image).transpose(1, 2, 0).copy()
+                        )
+                    if latents is not None:
+                        latents.append(self.rssm.get_feat(posterior)[0].cpu().numpy())
+
+                prev_state = posterior
+                prev_action = torch.as_tensor(
+                    np.asarray(executed, dtype=np.float32), device=self.device
+                ).reshape(1, self.action_size)
+                is_first = False
+                obs = next_obs
+
+        latents_arr = (
+            np.array(latents) if latents is not None and len(latents) > 0 else None
+        )
+        max_videos = int(getattr(self.args, "max_videos_to_save", 2))
+        return (
+            episode_rewards,
+            np.array(video_images[:max_videos], dtype=object),
+            latents_arr,
+        )
+
+    # ------------------------------------------------------------------
+    # Checkpoints
+    # ------------------------------------------------------------------
+
+    def save(self, save_path: str) -> None:
+        """Write model, optimizer, and normalizer state to ``save_path``."""
+        _save_config_next_to_checkpoint(self.args, save_path)
+        torch.save(
+            {
+                "config": self.args.to_dict(),
+                "obs_shape": tuple(self.obs_shape),
+                "action_size": int(self.action_size),
+                "rssm": self.rssm.state_dict(),
+                "obs_encoder": self.obs_encoder.state_dict(),
+                "obs_decoder": self.obs_decoder.state_dict(),
+                "reward_model": self.reward_model.state_dict(),
+                "continue_model": self.continue_model.state_dict(),
+                "value_model": self.value_model.state_dict(),
+                "slow_value_model": self.slow_value_model.state_dict(),
+                "actor": self.actor.state_dict(),
+                "world_model_optimizer": self.world_model_opt.state_dict(),
+                "actor_optimizer": self.actor_opt.state_dict(),
+                "value_optimizer": self.value_opt.state_dict(),
+                "return_norm": self.return_norm.state_dict(),
+                "updates": self._updates,
+            },
+            save_path,
+        )
+
+    def restore_checkpoint(
+        self, ckpt_path: str | Path, map_location: Any = None
+    ) -> None:
+        """Load model, optimizer, and normalizer state from a checkpoint."""
+        checkpoint = torch.load(
+            ckpt_path, map_location=map_location or self.device, weights_only=True
+        )
+        self.rssm.load_state_dict(checkpoint["rssm"])
+        self.obs_encoder.load_state_dict(checkpoint["obs_encoder"])
+        self.obs_decoder.load_state_dict(checkpoint["obs_decoder"])
+        self.reward_model.load_state_dict(checkpoint["reward_model"])
+        self.continue_model.load_state_dict(checkpoint["continue_model"])
+        self.value_model.load_state_dict(checkpoint["value_model"])
+        self.actor.load_state_dict(checkpoint["actor"])
+        if checkpoint.get("slow_value_model") is not None:
+            self.slow_value_model.load_state_dict(checkpoint["slow_value_model"])
+        else:
+            self.slow_value_model.load_state_dict(self.value_model.state_dict())
+
+        self.world_model_opt.load_state_dict(checkpoint["world_model_optimizer"])
+        self.actor_opt.load_state_dict(checkpoint["actor_optimizer"])
+        self.value_opt.load_state_dict(checkpoint["value_optimizer"])
+        if checkpoint.get("return_norm") is not None:
+            self.return_norm.load_state_dict(checkpoint["return_norm"])
+        self._updates = int(checkpoint.get("updates", 0))
+
+
+def _is_true_termination(info: Any, done: bool | float) -> float:
+    """Distinguish a genuine terminal state from a time-limit truncation.
+
+    The continue predictor should learn that the episode really ended, not that
+    a wall-clock budget expired; bootstrapping is still correct after a
+    truncation. TorchWM's ``TimeLimit`` wrapper sets ``info["time_limit"]``.
+    """
+    if not done:
+        return 0.0
+    if isinstance(info, dict):
+        if info.get("time_limit") or info.get("TimeLimit.truncated"):
+            return 0.0
+        if "discount" in info:
+            # dm_control style: discount == 1 at a truncation boundary.
+            try:
+                return 0.0 if float(info["discount"]) == 1.0 else 1.0
+            except (TypeError, ValueError):
+                pass
+    return 1.0
+
+
+def _resolve_actor_dist(env: Any) -> str:
+    """Choose the policy distribution from an environment's action space."""
+    action_space = env.action_space
+    if hasattr(action_space, "n") and not hasattr(action_space, "low"):
+        return "onehot"
+    # The OneHotAction wrapper exposes a Box space but keeps a discrete
+    # underlying space, which it advertises through `_env.action_space`.
+    inner = getattr(env, "_env", None)
+    if inner is not None and hasattr(getattr(inner, "action_space", None), "n"):
+        return "onehot"
+    return "normal"
+
+
+class DreamerV3Agent(DreamerAgent):
+    """High-level DreamerV3 agent: builds environments, trains, and evaluates.
+
+    Usage::
+
+        import torchwm
+
+        agent = torchwm.create_model(
+            "dreamer-v3", env="Pendulum-v1", env_backend="gym", total_steps=5_000
+        )
+        agent.train()
+    """
+
+    _core_cls = DreamerV3
+    _config_cls = DreamerV3Config
+
+    def _build_core(
+        self, obs_shape: Any, action_size: int, device: torch.device
+    ) -> DreamerV3:
+        args = cast(DreamerV3Config, self.args)
+        if str(getattr(args, "actor_dist", "auto")) == "auto":
+            args.actor_dist = _resolve_actor_dist(self.train_env)
+        args.resolve()
+        return DreamerV3(args, obs_shape, action_size, device, args.restore)

--- a/world_models/optim/__init__.py
+++ b/world_models/optim/__init__.py
@@ -1,0 +1,5 @@
+"""Optimizers and gradient transforms used by TorchWM agents."""
+
+from .laprop import LaProp, adaptive_grad_clip_
+
+__all__ = ["LaProp", "adaptive_grad_clip_"]

--- a/world_models/optim/laprop.py
+++ b/world_models/optim/laprop.py
@@ -1,0 +1,153 @@
+"""LaProp optimizer and adaptive gradient clipping, as used by DreamerV3.
+
+LaProp separates momentum from adaptivity: gradients are first normalized by an
+RMSProp-style second-moment estimate and only then smoothed by momentum. Adam,
+by contrast, computes both the momentum and the normalizer from the raw
+gradients. The LaProp ordering tolerates a much smaller epsilon (DreamerV3 uses
+``1e-20``) and avoids the occasional instabilities observed with Adam.
+
+Adaptive gradient clipping (AGC) rescales each parameter's gradient when its
+norm exceeds a fraction of the norm of the weights it belongs to. Because the
+threshold is relative to the weights, it does not need to be retuned when loss
+functions or loss scales change.
+
+References:
+    Ziyin et al., 2020 - https://arxiv.org/abs/2002.04839 (LaProp)
+    Brock et al., 2021 - https://arxiv.org/abs/2102.06171 (AGC)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable
+
+import torch
+from torch.optim import Optimizer
+
+__all__ = ["LaProp", "adaptive_grad_clip_"]
+
+
+def adaptive_grad_clip_(
+    parameters: Iterable[torch.Tensor],
+    clip: float = 0.3,
+    eps: float = 1e-3,
+) -> torch.Tensor:
+    """Clip gradients in place, per tensor, relative to the parameter norm.
+
+    Each parameter's gradient is scaled down so that its L2 norm does not exceed
+    ``clip * max(||w||, eps)``, where ``||w||`` is the L2 norm of the
+    corresponding parameter tensor. Gradients already below the threshold are
+    left untouched.
+
+    Args:
+        parameters: Parameters whose ``.grad`` should be clipped.
+        clip: Fraction of the weight norm allowed for the gradient norm.
+        eps: Floor on the weight norm, so zero-initialized tensors still train.
+
+    Returns:
+        The total gradient norm before clipping, for logging.
+    """
+    if clip <= 0.0:
+        raise ValueError(f"clip must be positive, got {clip}")
+
+    pairs = [(param, param.grad) for param in parameters if param.grad is not None]
+    if not pairs:
+        return torch.zeros(())
+
+    total_sq = torch.zeros((), device=pairs[0][1].device, dtype=torch.float32)
+    for param, grad in pairs:
+        grad_norm = grad.detach().float().norm(2)
+        total_sq = total_sq + grad_norm.pow(2)
+
+        param_norm = param.detach().float().norm(2).clamp(min=eps)
+        max_norm = clip * param_norm
+        # Clamping the scale at 1 keeps gradients within budget untouched.
+        scale = (max_norm / grad_norm.clamp(min=1e-12)).clamp(max=1.0)
+        grad.detach().mul_(scale.to(grad.dtype))
+
+    return total_sq.sqrt()
+
+
+class LaProp(Optimizer):
+    """LaProp: RMSProp normalization followed by momentum smoothing.
+
+    Args:
+        params: Iterable of parameters or parameter groups.
+        lr: Learning rate.
+        betas: ``(beta1, beta2)`` for the momentum and second-moment estimates.
+        eps: Term added to the denominator. LaProp tolerates values far smaller
+            than Adam's because the epsilon does not interact with momentum.
+        weight_decay: Decoupled weight decay coefficient (applied to the
+            parameters directly, not to the gradients).
+    """
+
+    def __init__(
+        self,
+        params: Any,
+        lr: float = 4e-5,
+        betas: tuple[float, float] = (0.9, 0.99),
+        eps: float = 1e-20,
+        weight_decay: float = 0.0,
+    ) -> None:
+        if lr < 0.0:
+            raise ValueError(f"Invalid learning rate: {lr}")
+        if eps < 0.0:
+            raise ValueError(f"Invalid epsilon: {eps}")
+        if not 0.0 <= betas[0] < 1.0:
+            raise ValueError(f"Invalid beta1: {betas[0]}")
+        if not 0.0 <= betas[1] < 1.0:
+            raise ValueError(f"Invalid beta2: {betas[1]}")
+        if weight_decay < 0.0:
+            raise ValueError(f"Invalid weight_decay: {weight_decay}")
+
+        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self, closure: Callable[[], float] | None = None) -> Any:
+        """Perform a single optimization step."""
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            beta1, beta2 = group["betas"]
+            lr = group["lr"]
+            eps = group["eps"]
+            weight_decay = group["weight_decay"]
+
+            for param in group["params"]:
+                if param.grad is None:
+                    continue
+                grad = param.grad
+                if grad.is_sparse:
+                    raise RuntimeError("LaProp does not support sparse gradients")
+
+                state = self.state[param]
+                if len(state) == 0:
+                    state["step"] = 0
+                    state["exp_avg"] = torch.zeros_like(param)
+                    state["exp_avg_sq"] = torch.zeros_like(param)
+
+                exp_avg = state["exp_avg"]
+                exp_avg_sq = state["exp_avg_sq"]
+                state["step"] += 1
+                step = state["step"]
+
+                bias_correction1 = 1.0 - beta1**step
+                bias_correction2 = 1.0 - beta2**step
+
+                # RMSProp normalization first ...
+                exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=1.0 - beta2)
+                denom = (exp_avg_sq / bias_correction2).sqrt_().add_(eps)
+                normalized = grad / denom
+
+                # ... then momentum on the already-normalized gradient.
+                exp_avg.mul_(beta1).add_(normalized, alpha=1.0 - beta1)
+
+                if weight_decay != 0.0:
+                    param.add_(param, alpha=-lr * weight_decay)
+
+                param.add_(exp_avg, alpha=-lr / bias_correction1)
+
+        return loss

--- a/world_models/utils/dreamer_v3_utils.py
+++ b/world_models/utils/dreamer_v3_utils.py
@@ -1,0 +1,305 @@
+"""Robustness primitives introduced by DreamerV3.
+
+This module collects the small, self-contained numerical tools that make
+DreamerV3 train with fixed hyperparameters across domains:
+
+* :class:`SymexpTwoHotDist` -- a categorical distribution over exponentially
+  spaced bins, trained on two-hot encoded targets. This decouples gradient
+  magnitudes from target magnitudes for the reward predictor and the critic.
+* :class:`ReturnNormalizer` -- percentile-based return scaling with a
+  denominator limit, used to keep the actor entropy regularizer on a fixed
+  scale regardless of reward magnitude or sparsity.
+* :func:`free_bits` -- clipping of the KL terms below one nat.
+* :func:`lambda_return` -- bootstrapped ``lambda``-returns.
+
+Reference:
+    Mastering Diverse Domains through World Models
+    Hafner et al., 2023 - https://arxiv.org/abs/2301.04104
+"""
+
+from __future__ import annotations
+
+import torch
+
+from world_models.utils.dreamer_utils import symexp, symlog
+
+__all__ = [
+    "SymexpTwoHotDist",
+    "ReturnNormalizer",
+    "free_bits",
+    "lambda_return",
+    "symexp",
+    "symlog",
+    "twohot",
+]
+
+
+def twohot(target: torch.Tensor, bins: torch.Tensor) -> torch.Tensor:
+    """Two-hot encode ``target`` against a sorted, monotonically increasing grid.
+
+    The two-hot encoding generalizes one-hot encoding to continuous values: all
+    entries are zero except at the two bins bracketing the target, whose weights
+    sum to one and are linearly interpolated by distance.
+
+    Args:
+        target: Tensor of arbitrary shape with real-valued targets.
+        bins: 1-D tensor of bin locations, sorted ascending.
+
+    Returns:
+        Tensor of shape ``(*target.shape, len(bins))``.
+    """
+    if bins.ndim != 1:
+        raise ValueError(f"bins must be 1-D, got shape {tuple(bins.shape)}")
+    num_bins = bins.shape[0]
+    if num_bins < 2:
+        raise ValueError("bins must contain at least two entries")
+
+    target = target.to(bins.dtype)
+    clipped = target.clamp(min=float(bins[0]), max=float(bins[-1]))
+
+    # Index of the lower bracketing bin. `bins[below] <= clipped <= bins[above]`.
+    below = bins.reshape(*([1] * clipped.ndim), num_bins) <= clipped.unsqueeze(-1)
+    below = below.sum(dim=-1) - 1
+    below = below.clamp(0, num_bins - 2)
+    above = below + 1
+
+    lower = bins[below]
+    upper = bins[above]
+    span = (upper - lower).clamp(min=torch.finfo(bins.dtype).eps)
+    weight_upper = ((clipped - lower) / span).clamp(0.0, 1.0)
+    weight_lower = 1.0 - weight_upper
+
+    encoded = torch.zeros(
+        *clipped.shape, num_bins, dtype=bins.dtype, device=bins.device
+    )
+    encoded.scatter_(-1, below.unsqueeze(-1), weight_lower.unsqueeze(-1))
+    encoded.scatter_add_(-1, above.unsqueeze(-1), weight_upper.unsqueeze(-1))
+    return encoded
+
+
+class SymexpTwoHotDist:
+    """Categorical distribution over exponentially spaced bins.
+
+    The network emits ``num_bins`` logits. Bin locations are
+    ``symexp(linspace(-symlog_range, +symlog_range, num_bins))``, so they span
+    many orders of magnitude while remaining dense near zero. Predictions are
+    read out as the probability-weighted average of the bin locations, which
+    lets the head output any continuous value in the covered interval.
+
+    Training minimizes the cross entropy against the two-hot encoded target.
+    Because the loss only depends on the predicted probabilities and not on the
+    bin locations, gradient magnitudes are decoupled from target magnitudes.
+
+    Args:
+        logits: Tensor of shape ``(*batch, num_bins)``.
+        num_bins: Number of bins.
+        symlog_range: Half-width of the grid in symlog space.
+    """
+
+    def __init__(
+        self,
+        logits: torch.Tensor,
+        num_bins: int = 255,
+        symlog_range: float = 20.0,
+    ) -> None:
+        if logits.shape[-1] != int(num_bins):
+            raise ValueError(
+                f"logits last dimension {logits.shape[-1]} does not match "
+                f"num_bins={num_bins}"
+            )
+        self.logits = logits
+        self.num_bins = int(num_bins)
+        self.symlog_range = float(symlog_range)
+        # Bins are always float32: symexp(20) overflows float16, so the grid
+        # must not follow an autocast dtype.
+        self.bins = symexp(
+            torch.linspace(
+                -self.symlog_range,
+                self.symlog_range,
+                self.num_bins,
+                device=logits.device,
+                dtype=torch.float32,
+            )
+        )
+
+    @property
+    def probs(self) -> torch.Tensor:
+        return torch.softmax(self.logits.float(), dim=-1)
+
+    @property
+    def mean(self) -> torch.Tensor:
+        """Expected value under the predicted bin probabilities.
+
+        Two precautions keep this accurate across the many orders of magnitude
+        the bins span. Positive and negative bins are accumulated separately,
+        each from small to large magnitude, and the reduction runs in float64.
+        Without the wider accumulator, cancellation between the two halves
+        leaves a residual on the order of the largest bin's float32 ulp -- which
+        for the default grid means a zero-initialized head would predict a
+        reward of about -2 instead of exactly 0.
+        """
+        probs = self.probs.double()
+        bins = self.bins.double()
+        weighted = probs * bins
+        negative = weighted[..., self.bins < 0]
+        positive = weighted[..., self.bins >= 0]
+        # Reverse the negative half so both halves accumulate small -> large.
+        negative_sum = torch.flip(negative, dims=(-1,)).sum(dim=-1)
+        positive_sum = positive.sum(dim=-1)
+        return (negative_sum + positive_sum).to(self.logits.dtype)
+
+    def mode(self) -> torch.Tensor:
+        return self.mean
+
+    def log_prob(self, target: torch.Tensor) -> torch.Tensor:
+        """Cross entropy against the two-hot encoding of ``target``.
+
+        Args:
+            target: Real-valued targets shaped like ``logits`` without the final
+                bin dimension.
+
+        Returns:
+            Log-probability tensor shaped like ``target``.
+        """
+        encoded = twohot(target.float(), self.bins)
+        return (torch.log_softmax(self.logits.float(), dim=-1) * encoded).sum(dim=-1)
+
+    def cross_entropy_to(self, other: "SymexpTwoHotDist") -> torch.Tensor:
+        """Cross entropy of this distribution against ``other``'s probabilities.
+
+        Used for the critic's EMA (slow target) regularizer, where the target is
+        a full distribution rather than a scalar.
+        """
+        target = other.probs.detach()
+        return -(torch.log_softmax(self.logits.float(), dim=-1) * target).sum(dim=-1)
+
+
+class ReturnNormalizer:
+    """Percentile-range return normalization with a denominator limit.
+
+    Divides returns by an exponentially smoothed estimate of the range between
+    the ``low`` and ``high`` percentiles. Only large return magnitudes are scaled
+    down: the denominator is ``max(limit, scale)``, so returns that are already
+    small pass through untouched. This preserves information about reward
+    frequency (unlike advantage normalization) and does not blow up under sparse
+    rewards (unlike standard-deviation normalization).
+
+    Args:
+        decay: EMA decay for the smoothed range.
+        limit: Lower bound on the denominator.
+        low: Lower percentile, in ``[0, 100]``.
+        high: Upper percentile, in ``[0, 100]``.
+    """
+
+    def __init__(
+        self,
+        decay: float = 0.99,
+        limit: float = 1.0,
+        low: float = 5.0,
+        high: float = 95.0,
+    ) -> None:
+        if not 0.0 <= low < high <= 100.0:
+            raise ValueError(f"Require 0 <= low < high <= 100, got {low} and {high}")
+        self.decay = float(decay)
+        self.limit = float(limit)
+        self.low = float(low)
+        self.high = float(high)
+        self._scale: torch.Tensor | None = None
+
+    @property
+    def scale(self) -> float:
+        """Current smoothed percentile range (before the limit is applied)."""
+        return 0.0 if self._scale is None else float(self._scale)
+
+    def update(self, returns: torch.Tensor) -> torch.Tensor:
+        """Update the EMA from a batch of returns and return the denominator."""
+        flat = returns.detach().reshape(-1).float()
+        quantiles = torch.quantile(
+            flat,
+            torch.tensor([self.low / 100.0, self.high / 100.0], device=flat.device),
+        )
+        batch_scale = (quantiles[1] - quantiles[0]).clamp(min=0.0)
+        if self._scale is None:
+            self._scale = batch_scale
+        else:
+            self._scale = (
+                self.decay * self._scale.to(batch_scale.device)
+                + (1.0 - self.decay) * batch_scale
+            )
+        return self.denominator(device=returns.device, dtype=returns.dtype)
+
+    def denominator(
+        self, device: torch.device | None = None, dtype: torch.dtype | None = None
+    ) -> torch.Tensor:
+        """Return ``max(limit, scale)`` as a tensor."""
+        value = 0.0 if self._scale is None else self._scale
+        tensor = torch.as_tensor(value, device=device, dtype=dtype)
+        return torch.clamp(tensor, min=self.limit)
+
+    def __call__(self, returns: torch.Tensor) -> torch.Tensor:
+        return returns / self.update(returns)
+
+    def state_dict(self) -> dict[str, float]:
+        return {
+            "scale": self.scale,
+            "decay": self.decay,
+            "limit": self.limit,
+            "low": self.low,
+            "high": self.high,
+        }
+
+    def load_state_dict(self, state: dict[str, float]) -> None:
+        self.decay = float(state.get("decay", self.decay))
+        self.limit = float(state.get("limit", self.limit))
+        self.low = float(state.get("low", self.low))
+        self.high = float(state.get("high", self.high))
+        scale = state.get("scale")
+        self._scale = None if scale is None else torch.as_tensor(float(scale))
+
+
+def free_bits(kl: torch.Tensor, nats: float = 1.0) -> torch.Tensor:
+    """Clip a KL term below ``nats`` so it stops contributing once minimized.
+
+    DreamerV3 applies this to both the dynamics and representation losses, which
+    lets the representation loss carry a small weight without collapsing to
+    trivially predictable (and uninformative) representations.
+    """
+    return torch.clamp(kl, min=float(nats))
+
+
+def lambda_return(
+    rewards: torch.Tensor,
+    values: torch.Tensor,
+    continues: torch.Tensor,
+    bootstrap: torch.Tensor,
+    lambda_: float = 0.95,
+) -> torch.Tensor:
+    """Compute bootstrapped ``lambda``-returns.
+
+    Implements ``R_t = r_t + gamma_t * ((1 - lambda) * v_t + lambda * R_{t+1})``
+    with ``R_T = bootstrap``, where ``gamma_t`` is folded into ``continues``
+    (that is, ``continues = discount * continue_flag``).
+
+    Args:
+        rewards: Rewards ``r_t``, shape ``(T, ...)``.
+        values: Value estimates ``v_t`` for the *next* state, shape ``(T, ...)``.
+        continues: Discounted continuation flags, shape ``(T, ...)``.
+        bootstrap: Value used to terminate the recursion, shape ``(...)``.
+        lambda_: Trace decay in ``[0, 1]``.
+
+    Returns:
+        Tensor of returns with shape ``(T, ...)``.
+    """
+    if not rewards.shape == values.shape == continues.shape:
+        raise ValueError(
+            "rewards, values and continues must share a shape; got "
+            f"{tuple(rewards.shape)}, {tuple(values.shape)}, {tuple(continues.shape)}"
+        )
+    horizon = rewards.shape[0]
+    interm = rewards + continues * values * (1.0 - lambda_)
+    outputs = []
+    accumulated = bootstrap
+    for t in range(horizon - 1, -1, -1):
+        accumulated = interm[t] + continues[t] * lambda_ * accumulated
+        outputs.append(accumulated)
+    return torch.flip(torch.stack(outputs, dim=0), dims=(0,))

--- a/world_models/utils/logging_utils.py
+++ b/world_models/utils/logging_utils.py
@@ -262,9 +262,17 @@ def collect_system_stats(device: torch.device | str | None = None) -> dict[str, 
             }
         )
         if hasattr(torch.cuda, "utilization"):
-            stats["system/gpu_utilization_percent"] = float(
-                torch.cuda.utilization(cuda_index)
-            )
+            # torch.cuda.utilization() goes through NVML, which is a separate
+            # optional package. Metrics collection must never be able to abort
+            # a training run, so a missing or unusable NVML is simply skipped.
+            try:
+                stats["system/gpu_utilization_percent"] = float(
+                    torch.cuda.utilization(cuda_index)
+                )
+            except Exception:
+                logging.getLogger(__name__).debug(
+                    "GPU utilization unavailable", exc_info=True
+                )
 
     return stats
 

--- a/world_models/vision/__init__.py
+++ b/world_models/vision/__init__.py
@@ -34,12 +34,16 @@ __all__ = [
     "ConvEncoder",
     "CNNEncoder",
     "IRISEncoder",
+    "DreamerV3Encoder",
     # Decoders
     "ConvDecoder",
     "CNNDecoder",
     "DenseDecoder",
     "ActionDecoder",
     "IRISDecoder",
+    "DreamerV3Decoder",
+    "DreamerV3Head",
+    "DreamerV3Actor",
     # Video Processing
     "VideoTokenizer",
     "create_video_tokenizer",
@@ -66,6 +70,10 @@ def __getattr__(name: str) -> Any:
         from .iris_encoder import IRISEncoder
 
         return IRISEncoder
+    if name == "DreamerV3Encoder":
+        from .dreamer_v3_nets import DreamerV3Encoder
+
+        return DreamerV3Encoder
 
     # Decoders
     if name == "ConvDecoder":
@@ -88,6 +96,18 @@ def __getattr__(name: str) -> Any:
         from .iris_decoder import IRISDecoder
 
         return IRISDecoder
+    if name == "DreamerV3Decoder":
+        from .dreamer_v3_nets import DreamerV3Decoder
+
+        return DreamerV3Decoder
+    if name == "DreamerV3Head":
+        from .dreamer_v3_nets import DreamerV3Head
+
+        return DreamerV3Head
+    if name == "DreamerV3Actor":
+        from .dreamer_v3_nets import DreamerV3Actor
+
+        return DreamerV3Actor
 
     # Video Processing
     if name == "VideoTokenizer":

--- a/world_models/vision/dreamer_v3_nets.py
+++ b/world_models/vision/dreamer_v3_nets.py
@@ -1,0 +1,455 @@
+"""Encoder, decoder, and prediction heads for DreamerV3.
+
+Compared to earlier Dreamer generations these networks differ in three ways:
+
+* **RMSNorm + SiLU** replace unnormalized ELU/ReLU stacks.
+* **Vector observations are symlog transformed** on the encoder input and on the
+  decoder target, which prevents large inputs from producing large
+  reconstruction gradients that would swamp the representation loss.
+* **Scalar heads emit two-hot logits over exponentially spaced bins** instead of
+  Gaussian parameters, and their output weights are zero-initialized so the
+  agent does not hallucinate rewards and values before it has learned anything.
+
+Both image (rank-3, ``(C, H, W)``) and vector (rank-1, ``(D,)``) observations are
+supported; the right stack is chosen from the observation rank.
+
+Reference:
+    Mastering Diverse Domains through World Models
+    Hafner et al., 2023 - https://arxiv.org/abs/2301.04104
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.distributions as distributions
+
+from world_models.layers.rms_norm import RMSNorm
+from world_models.utils.dreamer_utils import symlog
+from world_models.utils.dreamer_v3_utils import SymexpTwoHotDist
+
+__all__ = [
+    "ChannelRMSNorm",
+    "DreamerV3Encoder",
+    "DreamerV3Decoder",
+    "DreamerV3Head",
+    "DreamerV3Actor",
+    "count_parameters",
+    "head_input_size",
+    "preprocess_image",
+]
+
+_ACTIVATIONS: dict[str, type[nn.Module]] = {
+    "silu": nn.SiLU,
+    "swish": nn.SiLU,
+    "elu": nn.ELU,
+    "relu": nn.ReLU,
+    "gelu": nn.GELU,
+    "tanh": nn.Tanh,
+}
+
+
+def _activation(name: str) -> nn.Module:
+    try:
+        return _ACTIVATIONS[name.lower()]()
+    except KeyError as exc:
+        options = ", ".join(sorted(_ACTIVATIONS))
+        raise ValueError(f"Unknown activation {name!r}. Options: {options}") from exc
+
+
+def preprocess_image(obs: torch.Tensor) -> torch.Tensor:
+    """Scale raw ``uint8`` images to the ``[0, 1]`` range used by DreamerV3.
+
+    The decoder ends in a sigmoid, so targets live in ``[0, 1]`` rather than the
+    ``[-0.5, 0.5]`` range used by DreamerV1/V2.
+    """
+    return obs.to(torch.float32) / 255.0
+
+
+def _is_image(shape: Sequence[int]) -> bool:
+    return len(shape) == 3
+
+
+class ChannelRMSNorm(nn.Module):
+    """RMSNorm over the channel dimension of an ``(N, C, H, W)`` tensor."""
+
+    def __init__(self, channels: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.norm = RMSNorm(channels, eps=eps)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x.permute(0, 2, 3, 1)
+        x = self.norm(x)
+        return x.permute(0, 3, 1, 2)
+
+
+def _conv_out(size: int, kernel: int = 4, stride: int = 2, padding: int = 1) -> int:
+    return (size + 2 * padding - kernel) // stride + 1
+
+
+class DreamerV3Encoder(nn.Module):
+    """Encode observations into the embedding consumed by the RSSM posterior.
+
+    Args:
+        obs_shape: ``(C, H, W)`` for images or ``(D,)`` for vectors.
+        cnn_depth: Channel count of the first convolution; later layers double.
+        hidden_size: Width of the MLP used for vector observations.
+        mlp_layers: Number of hidden layers in the vector MLP.
+        min_resolution: Spatial size at which the convolution stack stops.
+        activation: Activation name.
+    """
+
+    def __init__(
+        self,
+        obs_shape: Sequence[int],
+        cnn_depth: int = 32,
+        hidden_size: int = 256,
+        mlp_layers: int = 3,
+        min_resolution: int = 4,
+        activation: str = "silu",
+    ) -> None:
+        super().__init__()
+        self.obs_shape = tuple(int(dim) for dim in obs_shape)
+        self.is_image = _is_image(self.obs_shape)
+        self.resolutions: list[tuple[int, int]] = []
+        self.out_channels = 0
+
+        if self.is_image:
+            channels, height, width = self.obs_shape
+            layers: list[nn.Module] = []
+            resolutions: list[tuple[int, int]] = [(int(height), int(width))]
+            in_ch = channels
+            depth = int(cnn_depth)
+            while min(height, width) > min_resolution and len(resolutions) <= 6:
+                layers.append(nn.Conv2d(in_ch, depth, 4, stride=2, padding=1))
+                layers.append(ChannelRMSNorm(depth))
+                layers.append(_activation(activation))
+                height, width = _conv_out(height), _conv_out(width)
+                resolutions.append((height, width))
+                in_ch = depth
+                depth *= 2
+            if len(resolutions) == 1:
+                raise ValueError(
+                    f"Image observations must be larger than min_resolution="
+                    f"{min_resolution}; got {self.obs_shape}."
+                )
+            self.conv = nn.Sequential(*layers)
+            self.resolutions = resolutions
+            self.out_channels = in_ch
+            self.embed_size = in_ch * height * width
+        else:
+            layers = []
+            in_features = self.obs_shape[0]
+            for _ in range(int(mlp_layers)):
+                layers.append(nn.Linear(in_features, hidden_size))
+                layers.append(RMSNorm(hidden_size))
+                layers.append(_activation(activation))
+                in_features = hidden_size
+            self.mlp = nn.Sequential(*layers)
+            self.embed_size = hidden_size
+
+    def forward(self, obs: torch.Tensor) -> torch.Tensor:
+        """Embed a batch of observations of shape ``(*batch, *obs_shape)``."""
+        batch_shape = obs.shape[: obs.ndim - len(self.obs_shape)]
+        flat = obs.reshape(-1, *self.obs_shape)
+        if self.is_image:
+            out = self.conv(flat)
+            out = out.reshape(out.shape[0], -1)
+        else:
+            out = self.mlp(symlog(flat))
+        return out.reshape(*batch_shape, self.embed_size)
+
+
+class DreamerV3Decoder(nn.Module):
+    """Reconstruct observations from model states.
+
+    Returns the predicted mean rather than a distribution: DreamerV3 trains the
+    decoder with a squared error (on symlog targets for vector inputs), so the
+    caller computes the loss directly.
+
+    Args:
+        feature_size: Size of the concatenated ``(z, h)`` model state.
+        obs_shape: ``(C, H, W)`` for images or ``(D,)`` for vectors.
+        encoder: Encoder whose resolution schedule should be mirrored. Required
+            for image observations so the transposed convolutions invert the
+            encoder exactly, including odd spatial sizes.
+        cnn_depth: Base channel count, matching the encoder.
+        hidden_size: Width of the MLP used for vector observations.
+        mlp_layers: Number of hidden layers in the vector MLP.
+        activation: Activation name.
+    """
+
+    def __init__(
+        self,
+        feature_size: int,
+        obs_shape: Sequence[int],
+        encoder: DreamerV3Encoder | None = None,
+        cnn_depth: int = 32,
+        hidden_size: int = 256,
+        mlp_layers: int = 3,
+        activation: str = "silu",
+    ) -> None:
+        super().__init__()
+        self.obs_shape = tuple(int(dim) for dim in obs_shape)
+        self.is_image = _is_image(self.obs_shape)
+        self.feature_size = int(feature_size)
+
+        if self.is_image:
+            if encoder is None or not encoder.is_image:
+                raise ValueError(
+                    "An image encoder must be supplied so the decoder can mirror "
+                    "its resolution schedule."
+                )
+            resolutions = list(encoder.resolutions)
+            self.start_resolution = resolutions[-1]
+            self.start_channels = encoder.out_channels
+            self.linear = nn.Linear(
+                self.feature_size,
+                self.start_channels
+                * self.start_resolution[0]
+                * self.start_resolution[1],
+            )
+
+            layers: list[nn.Module] = []
+            in_ch = self.start_channels
+            # Walk the encoder resolutions backwards, doubling spatial size and
+            # halving channels at every step.
+            for index in range(len(resolutions) - 1, 0, -1):
+                target_h, target_w = resolutions[index - 1]
+                current_h, current_w = resolutions[index]
+                out_pad_h = target_h - 2 * current_h
+                out_pad_w = target_w - 2 * current_w
+                if out_pad_h not in (0, 1) or out_pad_w not in (0, 1):
+                    raise ValueError(
+                        "Cannot invert the encoder resolution schedule for "
+                        f"{self.obs_shape}; got a mismatch at index {index}."
+                    )
+                last = index == 1
+                out_ch = self.obs_shape[0] if last else max(in_ch // 2, int(cnn_depth))
+                layers.append(
+                    nn.ConvTranspose2d(
+                        in_ch,
+                        out_ch,
+                        4,
+                        stride=2,
+                        padding=1,
+                        output_padding=(out_pad_h, out_pad_w),
+                    )
+                )
+                if not last:
+                    layers.append(ChannelRMSNorm(out_ch))
+                    layers.append(_activation(activation))
+                in_ch = out_ch
+            self.deconv = nn.Sequential(*layers)
+        else:
+            layers = []
+            in_features = self.feature_size
+            for _ in range(int(mlp_layers)):
+                layers.append(nn.Linear(in_features, hidden_size))
+                layers.append(RMSNorm(hidden_size))
+                layers.append(_activation(activation))
+                in_features = hidden_size
+            layers.append(nn.Linear(in_features, self.obs_shape[0]))
+            self.mlp = nn.Sequential(*layers)
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        """Predict observations from features of shape ``(*batch, feature_size)``."""
+        batch_shape = features.shape[:-1]
+        flat = features.reshape(-1, self.feature_size)
+        if self.is_image:
+            out = self.linear(flat)
+            out = out.reshape(
+                -1,
+                self.start_channels,
+                self.start_resolution[0],
+                self.start_resolution[1],
+            )
+            out = torch.sigmoid(self.deconv(out))
+        else:
+            out = self.mlp(flat)
+        return out.reshape(*batch_shape, *self.obs_shape)
+
+    def loss(self, prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        """Squared reconstruction error, summed over observation dimensions.
+
+        Vector targets are symlog transformed first; image targets are already in
+        ``[0, 1]`` and are compared directly against the sigmoid output.
+        """
+        if not self.is_image:
+            target = symlog(target)
+        error = 0.5 * (prediction - target).pow(2)
+        return error.reshape(*error.shape[: error.ndim - len(self.obs_shape)], -1).sum(
+            dim=-1
+        )
+
+
+class DreamerV3Head(nn.Module):
+    """MLP head for reward, value, and continuation prediction.
+
+    Args:
+        in_features: Size of the input features.
+        layers: Number of hidden layers.
+        units: Hidden width.
+        dist: One of ``"symexp_twohot"``, ``"binary"``, or ``"symlog_mse"``.
+        num_bins: Number of bins for the two-hot distribution.
+        symlog_range: Half-width of the two-hot grid in symlog space.
+        activation: Activation name.
+        zero_init_output: Zero-initialize the output layer. DreamerV3 does this
+            for the reward predictor and the critic so their initial predictions
+            are exactly zero, which measurably speeds up early learning.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        layers: int = 3,
+        units: int = 256,
+        dist: str = "symexp_twohot",
+        num_bins: int = 255,
+        symlog_range: float = 20.0,
+        activation: str = "silu",
+        zero_init_output: bool = True,
+    ) -> None:
+        super().__init__()
+        self.dist = dist
+        self.num_bins = int(num_bins)
+        self.symlog_range = float(symlog_range)
+
+        modules: list[nn.Module] = []
+        current = int(in_features)
+        for _ in range(int(layers)):
+            modules.append(nn.Linear(current, units))
+            modules.append(RMSNorm(units))
+            modules.append(_activation(activation))
+            current = int(units)
+
+        out_features = self.num_bins if dist == "symexp_twohot" else 1
+        output = nn.Linear(current, out_features)
+        if zero_init_output:
+            nn.init.zeros_(output.weight)
+            if output.bias is not None:
+                nn.init.zeros_(output.bias)
+        modules.append(output)
+        self.model = nn.Sequential(*modules)
+
+    def forward(self, features: torch.Tensor) -> Any:
+        out = self.model(features)
+        if self.dist == "symexp_twohot":
+            return SymexpTwoHotDist(out, self.num_bins, self.symlog_range)
+        if self.dist == "binary":
+            return distributions.Bernoulli(logits=out.squeeze(-1))
+        if self.dist == "symlog_mse":
+            return out.squeeze(-1)
+        raise ValueError(f"Unknown head distribution {self.dist!r}")
+
+
+class DreamerV3Actor(nn.Module):
+    """Policy head supporting one-hot discrete and continuous actions.
+
+    DreamerV3 uses the Reinforce estimator for both action types, so the head
+    always exposes an explicit distribution with ``log_prob`` and ``entropy``.
+
+    * Discrete actions use a one-hot categorical with the same 1% unimix as the
+      world model latents, which keeps log-probabilities finite.
+    * Continuous actions use a Normal whose mean is squashed by ``tanh`` and
+      whose standard deviation is bounded to ``[min_std, max_std]``. Actions are
+      clipped to the ``[-1, 1]`` action space by the environment wrapper.
+
+    Args:
+        in_features: Size of the model-state features.
+        action_size: Number of actions (discrete) or action dimensions.
+        discrete: Whether the action space is discrete.
+        layers: Number of hidden layers.
+        units: Hidden width.
+        unimix: Uniform mixture fraction for the discrete distribution.
+        min_std: Lower bound on the continuous standard deviation.
+        max_std: Upper bound on the continuous standard deviation.
+        activation: Activation name.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        action_size: int,
+        discrete: bool,
+        layers: int = 3,
+        units: int = 256,
+        unimix: float = 0.01,
+        min_std: float = 0.1,
+        max_std: float = 1.0,
+        activation: str = "silu",
+    ) -> None:
+        super().__init__()
+        self.action_size = int(action_size)
+        self.discrete = bool(discrete)
+        self.unimix = float(unimix)
+        self.min_std = float(min_std)
+        self.max_std = float(max_std)
+
+        modules: list[nn.Module] = []
+        current = int(in_features)
+        for _ in range(int(layers)):
+            modules.append(nn.Linear(current, units))
+            modules.append(RMSNorm(units))
+            modules.append(_activation(activation))
+            current = int(units)
+        out_features = self.action_size if self.discrete else 2 * self.action_size
+        modules.append(nn.Linear(current, out_features))
+        self.model = nn.Sequential(*modules)
+
+    def dist(self, features: torch.Tensor) -> distributions.Distribution:
+        """Return the action distribution for the given features."""
+        out = self.model(features)
+        if self.discrete:
+            logits = out
+            if self.unimix > 0.0:
+                probs = torch.softmax(logits, dim=-1)
+                uniform = torch.ones_like(probs) / float(self.action_size)
+                probs = (1.0 - self.unimix) * probs + self.unimix * uniform
+                logits = torch.log(probs)
+            return distributions.OneHotCategorical(logits=logits)
+        mean, std = torch.chunk(out, 2, dim=-1)
+        mean = torch.tanh(mean)
+        std = (self.max_std - self.min_std) * torch.sigmoid(std + 2.0) + self.min_std
+        return distributions.Independent(distributions.Normal(mean, std), 1)
+
+    def forward(
+        self, features: torch.Tensor, deterministic: bool = False
+    ) -> torch.Tensor:
+        """Sample (or take the mode of) an action."""
+        dist = self.dist(features)
+        if deterministic:
+            if self.discrete:
+                logits = torch.as_tensor(getattr(dist, "logits"))
+                index = torch.argmax(logits, dim=-1)
+                return torch.nn.functional.one_hot(index, self.action_size).to(
+                    logits.dtype
+                )
+            return dist.mean
+        return dist.sample()
+
+    def add_exploration(
+        self, action: torch.Tensor, action_noise: float = 0.0
+    ) -> torch.Tensor:
+        """Optional additive exploration noise for continuous actions.
+
+        DreamerV3 relies on its entropy regularizer rather than injected noise,
+        so this is a no-op unless ``action_noise`` is explicitly set.
+        """
+        if action_noise <= 0.0 or self.discrete:
+            return action
+        noisy = action + torch.randn_like(action) * action_noise
+        return torch.clamp(noisy, -1.0, 1.0)
+
+
+def head_input_size(latent_dim: int, latent_classes: int, deter_size: int) -> int:
+    """Feature size produced by concatenating the flattened latent and ``h``."""
+    return int(latent_dim) * int(latent_classes) + int(deter_size)
+
+
+def count_parameters(module: nn.Module) -> int:
+    """Total parameter count of a module, for the model-size presets."""
+    return int(np.sum([param.numel() for param in module.parameters()]))


### PR DESCRIPTION
## Summary

Adds a complete DreamerV3 implementation to torchwm, including:

- **DreamerV3 agent** (`world_models/models/dreamer_v3.py`) - Full agent with world model, actor, and critic learned entirely in latent space
- **Categorical RSSM** (`world_models/models/categorical_rssm.py`) - Recurrent state-space model with categorical latents
- **Block GRU** (`world_models/layers/block_gru.py`) - Block-diagonal GRU layer used in DreamerV3
- **Laprop optimizer** (`world_models/optim/laprop.py`) - Loss-adaptive optimizer for stabilizing DreamerV3 training
- **DreamerV3 memory** (`world_models/memory/dreamer_v3_memory.py`) - Episodic replay buffer with fixed-size memory
- **Vision networks** (`world_models/vision/dreamer_v3_nets.py`) - CNN encoder/decoder tailored for DreamerV3
- **DreamerV3 config** (`world_models/configs/dreamer_v3_config.py`) - Structured config with all hyperparameters
- **Utility functions** (`world_models/utils/dreamer_v3_utils.py`) - Symlog, OneHotDist, and other helpers
- **Tests** (~1800 lines across 6 test files) for all components
- **Example** (`examples/dreamer_v3_example.py`) - End-to-end training example
- **Documentation** (`docs/source/dreamer_v3.md`) - Full API reference and usage guide
- **Updated public API** - Exports DreamerV3, CategoricalRSSM, DreamerV3Memory, Laprop in the package namespace